### PR TITLE
Use Specref FIPS ref.

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,12 +104,6 @@
           MULTICODEC: {
             title: "Multicodec",
             href: "https://github.com/multiformats/multicodec/",
-          },
-          "FIPS-186-5": {
-            title:    "FIPS PUB 186-5: Digital Signature Standard (DSS)",
-            href:     "https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf",
-            status:   "National Standard",
-            publisher:  "U.S. Department of Commerce/National Institute of Standards and Technology"
           }
         },
         lint: {"no-unused-dfns": false},


### PR DESCRIPTION
`FIPS-186-5` ref is now in the Specref DB, so it can be removed from `localBiblio`:
https://github.com/tobie/specref/pull/741
https://www.specref.org/?q=FIPS-186-5

There's a PR to get "National Standard" status included:
https://github.com/tobie/specref/pull/743


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/davidlehn/vc-di-ecdsa/pull/7.html" title="Last updated on Apr 25, 2023, 12:52 AM UTC (09b5a9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/7/cb24dba...davidlehn:09b5a9c.html" title="Last updated on Apr 25, 2023, 12:52 AM UTC (09b5a9c)">Diff</a>