### PR TITLE
Added missing proof canonicalization step.

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,8 +526,8 @@ Section <a href="#proof-verification-ecdsa-2019"></a>.
 
           <p>
 The required inputs to this algorithm are a <em>transformed data document</em>
-(<var>transformedDocument</var>) and <em>proof configuration</em>
-(<var>proofConfig</var>). A single <em>hash data</em> value represented as
+(<var>transformedDocument</var>) and <em>canonical proof configuration</em>
+(<var>canonicalProofConfig</var>). A single <em>hash data</em> value represented as
 series of bytes is produced as output.
           </p>
 
@@ -541,7 +541,7 @@ be exactly 32 bytes in size.
             <li>
 Let <var>proofConfigHash</var> be the result of applying the
 SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
-to the <var>proofConfig</var>. <var>proofConfigHash</var> will be
+to the <var>canonicalProofConfig</var>. <var>proofConfigHash</var> will be
 exactly 32 bytes in size.
             </li>
             <li>
@@ -605,7 +605,16 @@ Set <var>proofConfig</var>.<var>proofPurpose</var> to
 <var>options</var>.<var>proofPurpose</var>.
             </li>
             <li>
-Return <var>proofConfig</var>.
+Set <var>proofConfig</var>.<var>@context</var> to
+<var>unsecuredDocument</var>.<var>@context</var>
+            </li>
+            <li>
+Let <var>canonicalProofConfig</var> be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the <var>proofConfig</var>.
+            </li>
+            <li>
+Return <var>canonicalProofConfig</var>.
             </li>
           </ol>
 

--- a/index.html
+++ b/index.html
@@ -606,7 +606,7 @@ Set <var>proofConfig</var>.<var>proofPurpose</var> to
             </li>
             <li>
 Set <var>proofConfig</var>.<var>@context</var> to
-<var>unsecuredDocument</var>.<var>@context</var>
+<var>unsecuredDocument</var>.<var>@context</var>.
             </li>
             <li>
 Let <var>canonicalProofConfig</var> be the result of applying the


### PR DESCRIPTION
Section 3.1.5 Proof Configuration (ecdsa-2019) and Section 3.1.4 Hashing (ecdsa-2019) are updated to add the missing *proof options canonicalization* step. This is similar to the processing steps in the "EdDSA Cryptosuite v2022" see [3.1.5 Proof Configuration (eddsa-2022)](https://w3c.github.io/vc-di-eddsa/#proof-configuration-eddsa-2022) and [3.1.4 Hashing (eddsa-2022)](https://w3c.github.io/vc-di-eddsa/#hashing-eddsa-2022).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/10.html" title="Last updated on Jun 3, 2023, 5:29 PM UTC (13403b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/10/f6bec3b...Wind4Greg:13403b3.html" title="Last updated on Jun 3, 2023, 5:29 PM UTC (13403b3)">Diff</a>