### PR TITLE
Add JCS algorithm text

### DIFF
--- a/index.html
+++ b/index.html
@@ -958,7 +958,7 @@ Section 4: Retrieving Cryptographic Material</a>.
             </li>
             <li>
 Let <var>verificationResult</var> be the result of applying the verification
-algorithm Elliptic Curve Digital Signature Algorithm (ECDSA) [[FIPS-186-5]],
+algorithm, Elliptic Curve Digital Signature Algorithm (ECDSA) [[FIPS-186-5]],
 with <var>hashData</var> as the data to be verified against the
 <var>proofBytes</var> using the public key specified by
 <var>publicKeyBytes</var>.

--- a/index.html
+++ b/index.html
@@ -730,7 +730,7 @@ proof serialization algorithm</a> is defined in Section
           <p>
 To verify a proof, the algorithm in
 <a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
-Section 4.2: Verify Proof</a> in the Data Integrity
+Section 4.2: Verify Proof</a> of the Data Integrity
 [[VC-DATA-INTEGRITY]] specification MUST be executed.
 For that algorithm, the cryptographic suite specific
 <a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">

--- a/index.html
+++ b/index.html
@@ -819,8 +819,8 @@ to the <var>canonicalProofConfig</var>. <var>proofConfigHash</var> will be
 exactly 32 bytes in size.
             </li>
             <li>
-Let <var>hashData</var> be the result of joining <var>proofConfigHash</var> (the
-first hash) with <var>transformedDocumentHash</var> (the second hash).
+Let <var>hashData</var> be the result of concatenating <var>proofConfigHash</var> (the
+first hash) followed by <var>transformedDocumentHash</var> (the second hash).
             </li>
             <li>
 Return <var>hashData</var> as the <em>hash data</em>.

--- a/index.html
+++ b/index.html
@@ -711,7 +711,7 @@ To generate a proof, the algorithm in
 <a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
 Section 4.1: Add Proof</a> in the Data Integrity
 [[VC-DATA-INTEGRITY]] specification MUST be executed.
-For that algorithm, the cryptographic suite specific
+For that algorithm, the cryptographic suite-specific
 <a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
 transformation algorithm</a> is defined in Section
 <a href="#transformation-jcs-ecdsa-2019"></a>, the

--- a/index.html
+++ b/index.html
@@ -709,7 +709,7 @@ section also include the verification of such a data integrity proof.
           <p>
 To generate a proof, the algorithm in
 <a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
-Section 4.1: Add Proof</a> in the Data Integrity
+Section 4.1: Add Proof</a> of the Data Integrity
 [[VC-DATA-INTEGRITY]] specification MUST be executed.
 For that algorithm, the cryptographic suite-specific
 <a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">

--- a/index.html
+++ b/index.html
@@ -771,7 +771,7 @@ encoding.
             <li>
 If <var>options</var>.<var>type</var> is not set to the string
 `DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
-set to the string `jcs-ecdsa-2019` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+set to the string `jcs-ecdsa-2019`, then a `PROOF_TRANSFORMATION_ERROR` MUST be
 raised.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -802,7 +802,7 @@ into cryptographic hash data that is ready to be provided as input to the
 algorithms in Section <a href="#proof-serialization-jcs-ecdsa-2019"></a> or
 Section <a href="#proof-verification-jcs-ecdsa-2019"></a>. One must use the 
 hash algorithm appropriate in security level to the curve used, i.e., for curve
-P-256 one uses SHA-256 and for curve P-384 one uses SHA-384.
+P-256 one uses SHA-256, and for curve P-384 one uses SHA-384.
           </p>
 
           <p>
@@ -817,17 +817,16 @@ series of bytes is produced as output.
 Let <var>transformedDocumentHash</var> be the result of applying the SHA-256
 (SHA-2 with 256-bit output) or SHA-384 (SHA-2 with 384-bit output) 
 cryptographic hashing algorithm [[RFC6234]] to the 
-<var>transformedDocument</var> in the case of curve P-256 or curve P-384 
-respectively. <var>transformedDocumentHash</var> will be exactly 32 or 48 bytes
-in size respectively.
+respective curve P-256 or curve P-384 <var>transformedDocument</var>.
+Respective <var>transformedDocumentHash</var> will be exactly 32 or 48 bytes
+in size.
             </li>
             <li>
 Let <var>proofConfigHash</var> be the result of applying the SHA-256 
 (SHA-2 with 256-bit output) or SHA-384 (SHA-2 with 384-bit output) 
 cryptographic hashing algorithm [[RFC6234]] to the 
-<var>canonicalProofConfig</var> in the case of curve P-256 or curve P-384 
-respectively. <var>proofConfigHash</var> will be exactly 32 or 48 bytes in size 
-respectively.
+respective curve P-256 or curve P-384 <var>canonicalProofConfig</var>.
+Respective <var>proofConfigHash</var> will be exactly 32 or 48 bytes in size.
             </li>
             <li>
 Let <var>hashData</var> be the result of concatenating <var>proofConfigHash</var> (the

--- a/index.html
+++ b/index.html
@@ -692,6 +692,284 @@ Return <var>verificationResult</var> as the <em>verification result</em>.
 
         </section>
       </section>
+      <section>
+        <h3>jcs-ecdsa-2019</h3>
+
+        <p>
+The `jcs-ecdsa-2019` cryptographic suite takes an input document, canonicalizes
+the document using the JSON Canonicalization Scheme [[RFC8785]], and then 
+cryptographically hashes and signs the output
+resulting in the production of a data integrity proof. The algorithms in this
+section also include the verification of such a data integrity proof.
+        </p>
+
+        <section>
+          <h4>Add Proof (jcs-ecdsa-2019)</h4>
+
+          <p>
+To generate a proof, the algorithm in
+<a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
+Section 4.1: Add Proof</a> in the Data Integrity
+[[VC-DATA-INTEGRITY]] specification MUST be executed.
+For that algorithm, the cryptographic suite specific
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
+transformation algorithm</a> is defined in Section
+<a href="#transformation-jcs-ecdsa-2019"></a>, the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
+hashing algorithm</a> is defined in Section <a href="#hashing-jcs-ecdsa-2019"></a>,
+and the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
+proof serialization algorithm</a> is defined in Section
+<a href="#proof-serialization-jcs-ecdsa-2019"></a>.
+          </p>
+        </section>
+
+        <section>
+          <h4>Verify Proof (jcs-ecdsa-2019)</h4>
+
+          <p>
+To verify a proof, the algorithm in
+<a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
+Section 4.2: Verify Proof</a> in the Data Integrity
+[[VC-DATA-INTEGRITY]] specification MUST be executed.
+For that algorithm, the cryptographic suite specific
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
+transformation algorithm</a> is defined in Section
+<a href="#transformation-jcs-ecdsa-2019"></a>, the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
+hashing algorithm</a> is defined in Section <a href="#hashing-jcs-ecdsa-2019"></a>,
+and the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
+proof verification algorithm</a> is defined in Section
+<a href="#proof-verification-jcs-ecdsa-2019"></a>.
+          </p>
+        </section>
+
+        <section>
+          <h4>Transformation (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to transform an unsecured input document
+into a transformed document that is ready to be provided as input to the
+hashing algorithm in Section <a href="#hashing-jcs-ecdsa-2019"></a>.
+          </p>
+
+          <p>
+Required inputs to this algorithm are an
+<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
+unsecured data document</a> (<var>unsecuredDocument</var>) and
+transformation options (<var>options</var>). The
+transformation options MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and a cryptosuite
+identifier (<var>cryptosuite</var>). A <em>transformed data document</em> is
+produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
+encoding.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If <var>options</var>.<var>type</var> is not set to the string
+`DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
+set to the string `jcs-ecdsa-2019` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+raised.
+            </li>
+            <li>
+Let <var>canonicalDocument</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
+            </li>
+            <li>
+Set <var>output</var> to the value of <var>canonicalDocument</var>.
+            </li>
+            <li>
+Return <var>canonicalDocument</var> as the <em>transformed data document</em>.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h4>Hashing (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to cryptographically hash a
+<em>transformed data document</em> and <em>proof configuration</em>
+into cryptographic hash data that is ready to be provided as input to the
+algorithms in Section <a href="#proof-serialization-jcs-ecdsa-2019"></a> or
+Section <a href="#proof-verification-jcs-ecdsa-2019"></a>.
+          </p>
+
+          <p>
+The required inputs to this algorithm are a <em>transformed data document</em>
+(<var>transformedDocument</var>) and <em>canonical proof configuration</em>
+(<var>canonicalProofConfig</var>). A single <em>hash data</em> value represented as
+series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>transformedDocumentHash</var> be the result of applying the
+SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
+to the <var>transformedDocument</var>. <var>transformedDocumentHash</var> will
+be exactly 32 bytes in size.
+            </li>
+            <li>
+Let <var>proofConfigHash</var> be the result of applying the
+SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
+to the <var>canonicalProofConfig</var>. <var>proofConfigHash</var> will be
+exactly 32 bytes in size.
+            </li>
+            <li>
+Let <var>hashData</var> be the result of joining <var>proofConfigHash</var> (the
+first hash) with <var>transformedDocumentHash</var> (the second hash).
+            </li>
+            <li>
+Return <var>hashData</var> as the <em>hash data</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Configuration (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to generate a
+<em>proof configuration</em> from a set of <em>proof options</em>
+that is used as input to the <a href="#hashing-jcs-ecdsa-2019">proof hashing algorithm</a>.
+          </p>
+
+          <p>
+The required inputs to this algorithm are <em>proof options</em>
+(<var>options</var>). The <em>proof options</em> MUST contain a type identifier
+for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and MUST contain a cryptosuite
+identifier (<var>cryptosuite</var>). A <em>proof configuration</em>
+object is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>proofConfig</var> be an empty object.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>type</var> to
+<var>options</var>.<var>type</var>.
+            </li>
+            <li>
+If <var>options</var>.<var>cryptosuite</var> is set, set
+<var>proofConfig</var>.<var>cryptosuite</var> to its value.
+            </li>
+            <li>
+If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
+<var>proofConfig</var>.<var>cryptosuite</var> is not set to `jcs-ecdsa-2019`, an
+`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>created</var> to
+<var>options</var>.<var>created</var>. If the value is not a valid
+[[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>verificationMethod</var> to
+<var>options</var>.<var>verificationMethod</var>.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>proofPurpose</var> to
+<var>options</var>.<var>proofPurpose</var>.
+            </li>
+            <li>
+Let <var>canonicalProofConfig</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
+            </li>
+            <li>
+Return <var>canonicalProofConfig</var>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Serialization (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to serialize a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (<var>hashData</var>) and
+<em>proof options</em> (<var>options</var>). The
+<em>proof options</em> MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and MAY contain a cryptosuite
+identifier (<var>cryptosuite</var>). A single <em>digital proof</em> value
+represented as series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>privateKeyBytes</var> be the result of retrieving the
+private key bytes associated with the
+<var>options</var>.<var>verificationMethod</var> value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Retrieving Cryptographic Material</a>.
+            </li>
+            <li>
+Let <var>proofBytes</var> be the result of applying the Elliptic Curve Digital
+Signature Algorithm (ECDSA) [[FIPS-186-5]], with <var>hashData</var> as the data
+to be signed using the private key specified by <var>privateKeyBytes</var>.
+<var>proofBytes</var> will be exactly 64 bytes in size for a P-256 key, and
+96 bytes in size for a P-384 key.
+            </li>
+            <li>
+Return <var>proofBytes</var> as the <em>digital proof</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Verification (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to verify a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (<var>hashData</var>),
+a digital signature (<var>proofBytes</var>) and
+proof options (<var>options</var>). A <em>verification result</em>
+represented as a boolean value is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>publicKeyBytes</var> be the result of retrieving the
+public key bytes associated with the
+<var>options</var>.<var>verificationMethod</var> value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Retrieving Cryptographic Material</a>.
+            </li>
+            <li>
+Let <var>verificationResult</var> be the result of applying the verification
+algorithm Elliptic Curve Digital Signature Algorithm (ECDSA) [[FIPS-186-5]],
+with <var>hashData</var> as the data to be verified against the
+<var>proofBytes</var> using the public key specified by
+<var>publicKeyBytes</var>.
+            </li>
+            <li>
+Return <var>verificationResult</var> as the <em>verification result</em>.
+            </li>
+          </ol>
+
+        </section>
+      </section>
     </section>
     <section>
       <h2>Security Considerations</h2>

--- a/index.html
+++ b/index.html
@@ -732,7 +732,7 @@ To verify a proof, the algorithm in
 <a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
 Section 4.2: Verify Proof</a> of the Data Integrity
 [[VC-DATA-INTEGRITY]] specification MUST be executed.
-For that algorithm, the cryptographic suite specific
+For that algorithm, the cryptographic suite-specific
 <a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
 transformation algorithm</a> is defined in Section
 <a href="#transformation-jcs-ecdsa-2019"></a>, the

--- a/index.html
+++ b/index.html
@@ -942,7 +942,7 @@ in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
 <a data-cite="vc-data-integrity#algorithms">
 Section 4: Algorithms</a>. Required inputs are
 cryptographic hash data (<var>hashData</var>),
-a digital signature (<var>proofBytes</var>) and
+a digital signature (<var>proofBytes</var>), and
 proof options (<var>options</var>). A <em>verification result</em>
 represented as a boolean value is produced as output.
           </p>

--- a/index.html
+++ b/index.html
@@ -538,16 +538,16 @@ series of bytes is produced as output.
 Let <var>transformedDocumentHash</var> be the result of applying the
 SHA-256 (SHA-2 with 256-bit output) or SHA-384 (SHA-2 with 384-bit output) 
 cryptographic hashing algorithm [[RFC6234]] to the 
-<var>transformedDocument</var> in the case of curve P-256 or curve P-384 
-respectively. <var>transformedDocumentHash</var> will be exactly 32 or 48 bytes
-in size respectively.
+respective curve P-256 or curve P-384 <var>transformedDocument</var>.
+Respective <var>transformedDocumentHash</var> will be exactly 32 or 48 bytes
+in size.
             </li>
             <li>
 Let <var>proofConfigHash</var> be the result of applying the
 SHA-256 (SHA-2 with 256-bit output) or SHA-384 (SHA-2 with 384-bit output) 
-cryptographic hashing algorithm [[RFC6234]] to the <var>proofConfig</var> in 
-the case of curve P-256 or curve P-384 respectively. <var>proofConfigHash</var> 
-will be exactly 32 or 48 bytes in size respectively.
+cryptographic hashing algorithm [[RFC6234]] to the respective curve P-256 or curve P-384
+<var>proofConfig</var>. Respective <var>proofConfigHash</var> 
+will be exactly 32 or 48 bytes in size.
             </li>
             <li>
 Let <var>hashData</var> be the result of joining <var>proofConfigHash</var> (the

--- a/index.html
+++ b/index.html
@@ -521,7 +521,9 @@ The following algorithm specifies how to cryptographically hash a
 <em>transformed data document</em> and <em>proof configuration</em>
 into cryptographic hash data that is ready to be provided as input to the
 algorithms in Section <a href="#proof-serialization-ecdsa-2019"></a> or
-Section <a href="#proof-verification-ecdsa-2019"></a>.
+Section <a href="#proof-verification-ecdsa-2019"></a>. One must use the hash
+algorithm appropriate in security level to the curve used, i.e., for curve 
+P-256 one uses SHA-256 and for curve P-384 one uses SHA-384.
           </p>
 
           <p>
@@ -534,15 +536,18 @@ series of bytes is produced as output.
           <ol class="algorithm">
             <li>
 Let <var>transformedDocumentHash</var> be the result of applying the
-SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
-to the <var>transformedDocument</var>. <var>transformedDocumentHash</var> will
-be exactly 32 bytes in size.
+SHA-256 (SHA-2 with 256-bit output) or SHA-384 (SHA-2 with 384-bit output) 
+cryptographic hashing algorithm [[RFC6234]] to the 
+<var>transformedDocument</var> in the case of curve P-256 or curve P-384 
+respectively. <var>transformedDocumentHash</var> will be exactly 32 or 48 bytes
+in size respectively.
             </li>
             <li>
 Let <var>proofConfigHash</var> be the result of applying the
-SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
-to the <var>proofConfig</var>. <var>proofConfigHash</var> will be
-exactly 32 bytes in size.
+SHA-256 (SHA-2 with 256-bit output) or SHA-384 (SHA-2 with 384-bit output) 
+cryptographic hashing algorithm [[RFC6234]] to the <var>proofConfig</var> in 
+the case of curve P-256 or curve P-384 respectively. <var>proofConfigHash</var> 
+will be exactly 32 or 48 bytes in size respectively.
             </li>
             <li>
 Let <var>hashData</var> be the result of joining <var>proofConfigHash</var> (the
@@ -795,7 +800,9 @@ The following algorithm specifies how to cryptographically hash a
 <em>transformed data document</em> and <em>proof configuration</em>
 into cryptographic hash data that is ready to be provided as input to the
 algorithms in Section <a href="#proof-serialization-jcs-ecdsa-2019"></a> or
-Section <a href="#proof-verification-jcs-ecdsa-2019"></a>.
+Section <a href="#proof-verification-jcs-ecdsa-2019"></a>. One must use the 
+hash algorithm appropriate in security level to the curve used, i.e., for curve
+P-256 one uses SHA-256 and for curve P-384 one uses SHA-384.
           </p>
 
           <p>
@@ -807,16 +814,20 @@ series of bytes is produced as output.
 
           <ol class="algorithm">
             <li>
-Let <var>transformedDocumentHash</var> be the result of applying the
-SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
-to the <var>transformedDocument</var>. <var>transformedDocumentHash</var> will
-be exactly 32 bytes in size.
+Let <var>transformedDocumentHash</var> be the result of applying the SHA-256
+(SHA-2 with 256-bit output) or SHA-384 (SHA-2 with 384-bit output) 
+cryptographic hashing algorithm [[RFC6234]] to the 
+<var>transformedDocument</var> in the case of curve P-256 or curve P-384 
+respectively. <var>transformedDocumentHash</var> will be exactly 32 or 48 bytes
+in size respectively.
             </li>
             <li>
-Let <var>proofConfigHash</var> be the result of applying the
-SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
-to the <var>canonicalProofConfig</var>. <var>proofConfigHash</var> will be
-exactly 32 bytes in size.
+Let <var>proofConfigHash</var> be the result of applying the SHA-256 
+(SHA-2 with 256-bit output) or SHA-384 (SHA-2 with 384-bit output) 
+cryptographic hashing algorithm [[RFC6234]] to the 
+<var>canonicalProofConfig</var> in the case of curve P-256 or curve P-384 
+respectively. <var>proofConfigHash</var> will be exactly 32 or 48 bytes in size 
+respectively.
             </li>
             <li>
 Let <var>hashData</var> be the result of concatenating <var>proofConfigHash</var> (the

--- a/index.html
+++ b/index.html
@@ -800,7 +800,7 @@ Section <a href="#proof-verification-jcs-ecdsa-2019"></a>.
 
           <p>
 The required inputs to this algorithm are a <em>transformed data document</em>
-(<var>transformedDocument</var>) and <em>canonical proof configuration</em>
+(<var>transformedDocument</var>) and a <em>canonical proof configuration</em>
 (<var>canonicalProofConfig</var>). A single <em>hash data</em> value represented as
 series of bytes is produced as output.
           </p>


### PR DESCRIPTION
Added text for using JCS canonicalization algorithm. This parallels that done for the RDF algorithm and uses the name `jcs-ecdsa-2019`.

Cheer Greg


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/12.html" title="Last updated on Jun 16, 2023, 9:40 PM UTC (03baab3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/12/c4a8938...Wind4Greg:03baab3.html" title="Last updated on Jun 16, 2023, 9:40 PM UTC (03baab3)">Diff</a>