### PR TITLE
Add links to related specifications at top of document.

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,23 @@
           }
         },
         lint: {"no-unused-dfns": false},
-        postProcess: [restrictRefs]
+        postProcess: [restrictRefs],
+        otherLinks: [{
+          key: "Related Specifications",
+          data: [{
+            value: "The Verifiable Credentials Data Model v2.0",
+            href: "https://www.w3.org/TR/vc-data-model-2.0/"
+          }, {
+            value: "Verifiable Credential Data Integrity v1.0",
+            href: "https://www.w3.org/TR/vc-data-integrity/"
+          }, {
+            value: "The Edwards Digital Signature Algorithm Cryptosuites v1.0",
+            href: "https://www.w3.org/TR/vc-di-eddsa/"
+          }, {
+            value: "The BBS Digital Signature Algorithm Cryptosuites v1.0",
+            href: "https://www.w3.org/TR/vc-di-bbs/"
+          }]
+        }]
       };
     </script>
     <style>


### PR DESCRIPTION
This PR adds a list of related specifications to the top of the ECDSA Cryptosuites specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/pull/14.html" title="Last updated on Jul 6, 2023, 11:22 AM UTC (23b1ec8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/14/c29ad2a...23b1ec8.html" title="Last updated on Jul 6, 2023, 11:22 AM UTC (23b1ec8)">Diff</a>