### PR TITLE
Set the normative definition of Multikey to the Data Integrity spec.

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,11 +277,13 @@ suites defined in this specification.
           <p>
 The `publicKeyMultibase` property represents a Multibase-encoded Multikey
 expression of a P-256 or P-384 public key. The encoding of a P-256 public key is
-the two-byte prefix `0x1200` followed by the 33-byte compressed public key data.
+the two-byte prefix `0x8024` (the varint expression of `0x1200`) followed
+by the 33-byte compressed public key data.
 The 35 byte value is then encoded using base58-btc (`z`) as the prefix. The
-encoding of a P-384 public key is the two-byte prefix `0x1201` followed by the
-49-byte compressed public key data. The 51 byte value is then encoded using
-base58-btc (`z`) as the prefix. Any other encodings MUST NOT be allowed.
+encoding of a P-384 public key is the two-byte prefix `0x8124` (the varint
+expression of `0x1201`) followed by the 49-byte compressed public key data.
+The 51 byte value is then encoded using base58-btc (`z`) as the prefix. Any
+other encodings MUST NOT be allowed.
           </p>
 
           <p class="advisement">

--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@ These verification methods are used to verify Data Integrity Proofs
 [[VC-DATA-INTEGRITY]] produced using Elliptic Curve cryptographic key material
 that is compliant with [[FIPS-186-5]]. The encoding formats for these key types
 are provided in this section. Lossless cryptographic key transformation
-processes that result in equivalent cryptographic key material MAY be utilized
+processes that result in equivalent cryptographic key material MAY be used
 during the processing of digital signatures.
         </p>
 
@@ -279,10 +279,10 @@ The `publicKeyMultibase` property represents a Multibase-encoded Multikey
 expression of a P-256 or P-384 public key. The encoding of a P-256 public key is
 the two-byte prefix `0x8024` (the varint expression of `0x1200`) followed
 by the 33-byte compressed public key data.
-The 35 byte value is then encoded using base58-btc (`z`) as the prefix. The
+The 35-byte value is then encoded using base58-btc (`z`) as the prefix. The
 encoding of a P-384 public key is the two-byte prefix `0x8124` (the varint
 expression of `0x1201`) followed by the 49-byte compressed public key data.
-The 51 byte value is then encoded using base58-btc (`z`) as the prefix. Any
+The 51-byte value is then encoded using base58-btc (`z`) as the prefix. Any
 other encodings MUST NOT be allowed.
           </p>
 

--- a/index.html
+++ b/index.html
@@ -249,52 +249,39 @@ JSON-LD.
 
       <p>
 The following sections outline the data model that is used by this specification
-for <a>verification methods</a> and <a>data integrity proof</a> formats.
+to express verification methods, such as cryptographic public keys, and
+data integrity proofs, such as digital signatures.
       </p>
 
       <section>
         <h3>Verification Methods</h3>
-        <p>
-The cryptographic material used to verify a <a>data integrity proof</a> is
-called the <a>verification method</a>. This suite relies on public key material
-represented using [[MULTIBASE]] and [[MULTICODEC]]. This suite supports public
-key use for both digital signature generation and verification, according to
-[[FIPS-186-5]].
-        </p>
 
         <p>
-This suite MAY be used to verify Data Integrity Proofs [[VC-DATA-INTEGRITY]]
-produced by ECDSA public key material encoded as a
-<a href="#multikey">Multikey</a>. Loss-less key transformation processes that
-result in equivalent cryptographic material MAY be utilized.
+These verification methods are used to verify Data Integrity Proofs
+[[VC-DATA-INTEGRITY]] produced using Elliptic Curve cryptographic key material
+that is compliant with [[FIPS-186-5]]. The encoding formats for these key types
+are provided in this section. Lossless cryptographic key transformation
+processes that result in equivalent cryptographic key material MAY be utilized
+during the processing of digital signatures.
         </p>
 
         <section>
           <h4>Multikey</h4>
 
-          <p class="issue">
-This definition should go in the Data Integrity specification and referenced
-from there.
+          <p>
+The <a data-cite="VC-DATA-INTEGRITY#multikey">Multikey format</a>, as defined in
+[[VC-DATA-INTEGRITY]], is used to express public keys for the cryptographic
+suites defined in this specification.
           </p>
 
           <p>
-The `type` of the verification method MUST be `Multikey`.
-          </p>
-
-          <p>
-The `controller` of the verification method MUST be a URL.
-          </p>
-
-          <p>
-The `publicKeyMultibase` property of the verification method MUST be
-a public key encoded according to [[MULTICODEC]] and formatted according to
-[[MULTIBASE]]. The multicodec encoding of a P-256 public key is the
-two-byte prefix `0x1200` followed by the 33-byte compressed public key data.
-The 35 byte value is then encoded using base58-btc (`z`) as the prefix.
-The multicodec encoding of a P-384 public key is the
-two-byte prefix `0x1201` followed by the 49-byte compressed public key data.
-The 51 byte value is then encoded using base58-btc (`z`) as the prefix.
-Any other encodings MUST NOT be allowed.
+The `publicKeyMultibase` property represents a Multibase-encoded Multikey
+expression of a P-256 or P-384 public key. The encoding of a P-256 public key is
+the two-byte prefix `0x1200` followed by the 33-byte compressed public key data.
+The 35 byte value is then encoded using base58-btc (`z`) as the prefix. The
+encoding of a P-384 public key is the two-byte prefix `0x1201` followed by the
+49-byte compressed public key data. The 51 byte value is then encoded using
+base58-btc (`z`) as the prefix. Any other encodings MUST NOT be allowed.
           </p>
 
           <p class="advisement">
@@ -360,23 +347,6 @@ key. Implementations of this specification will raise errors in the event of a
 }
           </pre>
         </section>
-
-        <p class="issue" title="Refer normatively to a Multikey specification">
-This specification should not specify multikey formats. It should, instead,
-point to a multikey registry and/or specification. Examples of these
-sorts of documents include the DID Specification Registries for <a
-href="https://www.w3.org/TR/did-spec-registries/#verification-method-types">
-Verification Method Types</a>, the key types in the <a
-href="https://ns.did.ai/suites/multikey-2021/v1/">
-Multikey2021 JSON-LD Context</a>, and key definitions in the <a
-href="https://w3c-ccg.github.io/security-vocab/">Security Vocabulary</a>.
-Ideally, the specification that this one points to would define all possible
-multikeys listed in the <a href="https://github.com/multiformats/multicodec/blob/master/table.csv">Multicodec Registry</a>
-and define how to encode them as multibase values in fields such as
-`publicKeyMultibase` and `secretKeyMultibase`. The referenced specification
-should also include an extensibility mechanism and registry for new values as
-they are added to the Multicodec Registry.
-        </p>
 
       </section>
 


### PR DESCRIPTION
This PR points the ECDSA Cryptosuites to the normative definition of Multikey in the VC Data Integrity specification (instead of re-defining it in the ECDSA cryptosuite specification). This allows much of the normative language to now be deduplicated between the VC Data Integrity spec and the ECDSA cryptosuite.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 23, 2023, 10:55 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fvc-di-ecdsa%2F9126f04b1262e436d214d30b0659cd5a9e2a2bd7%2Findex.html%3FisPreview%3Dtrue)

```
Failed to launch the browser process!
[3254525:3254539:0723/225520.823462:ERROR:bus.cc(399)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
[3254525:3254539:0723/225520.823624:ERROR:bus.cc(399)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
[3254525:3254539:0723/225520.823652:ERROR:bus.cc(399)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
[3254525:3254539:0723/225520.823682:ERROR:bus.cc(399)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")
[0723/225520.837239:ERROR:file_io_posix.cc(144)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[0723/225520.837355:ERROR:file_io_posix.cc(144)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
[0723/225520.854873:ERROR:nacl_helper_linux.cc(355)] NaCl helper process running without a sandbox!
Most likely you need to configure your SUID sandbox correctly


TROUBLESHOOTING: https://pptr.dev/troubleshooting

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/vc-di-ecdsa%2316.)._
</details>
