### PR TITLE
Add Greg and Sebastian as Editors to ECDSA Cryptosuites

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,6 @@
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a
 # pull request.
-*       @msporny @martyr280
+*       @msporny @martyr280 @Wind4Greg @seabass-labrax
 
 # See CODEOWNERS syntax here: https://help.github.com/articles/about-codeowners/#codeowners-syntax

--- a/index.html
+++ b/index.html
@@ -56,10 +56,10 @@
           w3cid: 127611
         }, {
           name: "Greg Bernstein", url: "https://www.grotto-networking.com/",
-          company: "Invited Expert", w3cid: 0
+          company: "Invited Expert", w3cid: 140479
         }, {
           name: "Sebastian Crane", url: "https://github.com/seabass-labrax",
-          company: "Invited Expert", w3cid: 0
+          company: "Invited Expert", w3cid: 140132
         }],
 
         // authors, add as many as you like.

--- a/index.html
+++ b/index.html
@@ -54,6 +54,12 @@
           company: "RANDA Solutions",
           companyURL: "https://www.randasolutions.com/",
           w3cid: 127611
+        }, {
+          name: "Greg Bernstein", url: "https://www.grotto-networking.com/",
+          company: "Invited Expert", w3cid: 0
+        }, {
+          name: "Sebastian Crane", url: "https://github.com/seabass-labrax",
+          company: "Invited Expert", w3cid: 0
         }],
 
         // authors, add as many as you like.


### PR DESCRIPTION
This PR adds Greg and Sebastian as Editors to the ECDSA Cryptosuites. The PR shouldn't be processed until after Sebastian's IE application has been processed. /cc @Wind4Greg @seabass-labrax


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/pull/17.html" title="Last updated on Jul 13, 2023, 9:54 PM UTC (3484ee3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/17/3d45e49...3484ee3.html" title="Last updated on Jul 13, 2023, 9:54 PM UTC (3484ee3)">Diff</a>