### PR TITLE
Remove "detached". Clarify `proofValue` meanging

### DIFF
--- a/index.html
+++ b/index.html
@@ -433,8 +433,8 @@ match the verification relationship expressed by the verification method
 The `proofValue` property of the proof MUST be an ECDSA or deterministic ECDSA
 signature produced according to [[FIPS-186-5]] using the curves and hashes as
 specified in section <a href="#algorithms"></a>, encoded according to section 7 
-of [[RFC4754]], and serialized according to [[MULTIBASE]] using the base58-btc 
-base encoding.
+of [[RFC4754]] (sometimes referred to as the IEEE P1363 format), and serialized
+according to [[MULTIBASE]] using the base58-btc base encoding.
           </p>
 
           <pre class="example nohighlight"

--- a/index.html
+++ b/index.html
@@ -432,8 +432,9 @@ match the verification relationship expressed by the verification method
           <p>
 The `proofValue` property of the proof MUST be an ECDSA or deterministic ECDSA
 signature produced according to [[FIPS-186-5]] using the curves and hashes as
-specified in section <a href="#algorithms"></a> and encoded according to 
-[[MULTIBASE]] using the base58-btc base encoding.
+specified in section <a href="#algorithms"></a>, encoded according to section 7 
+of [[RFC4754]], and serialized according to [[MULTIBASE]] using the base58-btc 
+base encoding.
           </p>
 
           <pre class="example nohighlight"

--- a/index.html
+++ b/index.html
@@ -430,9 +430,10 @@ match the verification relationship expressed by the verification method
 `controller`.
           </p>
           <p>
-The `proofValue` property of the proof MUST be a detached ECDSA
-produced according to [[FIPS-186-5]], encoded according to [[MULTIBASE]] using
-the base58-btc base encoding.
+The `proofValue` property of the proof MUST be an ECDSA or deterministic ECDSA
+signature produced according to [[FIPS-186-5]] using the curves and hashes as
+specified in section <a href="#algorithms"></a> and encoded according to 
+[[MULTIBASE]] using the base58-btc base encoding.
           </p>
 
           <pre class="example nohighlight"


### PR DESCRIPTION
This PR attempts to address issue https://github.com/w3c/vc-di-ecdsa/issues/15. The cited reference, FIPS 186-5 (2023) does not specify a "detached ECDSA signature" it specifies "An ECDSA or deterministic ECDSA digital signature" procedure which is dependent upon having appropriate elliptic curves and hashes specified (which do in the algorithms section of the document).

This PR removes the potentially misleading "detached" term and provides clarification of where to find curve and hash specifics.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/18.html" title="Last updated on Jul 24, 2023, 10:00 PM UTC (257fb92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/18/8bdbbab...Wind4Greg:257fb92.html" title="Last updated on Jul 24, 2023, 10:00 PM UTC (257fb92)">Diff</a>