### PR TITLE
Add helper functions for performing selective disclosure

### DIFF
--- a/index.html
+++ b/index.html
@@ -1328,7 +1328,7 @@ produced as output.
 
           <ol class="algorithm">
             <li>
-Run the RDF Dataset Canonicalization Algorithm [[RDFC-1.0]] on
+Run the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] on
 <var>document</var>, passing any custom options (such as a document loader), and
 get the canonicalized dataset as output, which includes a canonical bnode
 identifier map, <var>canonicalIdMap</var>.
@@ -1677,7 +1677,7 @@ If `pointers` is empty, return `null`.
             </li>
             <li>
 Initialize `frame` to an initial frame passing `document` as `value` to
-"createInitialFrame".
+the algorithm in Section <a href="#createinitialframe"></a>.
             </li>
             <li>
 For each `pointer` in `pointers` walk the document from root to the pointer
@@ -1697,10 +1697,11 @@ Initialize `value` to `parentValue`.
 Initialize `valueFrame` to `parentFrame`.
               </li>
               <li>
-Parse the `pointer` into an array of `paths` using "pointerToPaths".
+Parse the `pointer` into an array of `paths` using the algorithm in
+Section <a href="#jsonpointertopaths"></a>.
               </li>
               <li>
-For each `path` in `paths:
+For each `path` in `paths`:
               </li>
               <ol class="algorithm">
                 <li>
@@ -1725,7 +1726,7 @@ If `value` is an array, set `valueFrame` to an empty array.
                   </li>
                   <li>
 Otherwise, set `valueFrame` to an initial frame passing `value` to
-"createInitialFrame".
+the algorithm in Section <a href="#createinitialframe"></a>.
                   </li>
                   <li>
 Set `parentFrame[path]` to `valueFrame`.
@@ -1772,7 +1773,6 @@ Return `frame`.
               </li>
             </ol>
           </ol>
-
         </section>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -1447,7 +1447,6 @@ Return <em>skolemizedNquads</em>.
           </ol>
         </section>
 
-
         <section>
           <h4>deskolemize</h4>
 
@@ -1480,6 +1479,39 @@ Append <em>s2</em> to <em>deskolemizedNquads</em>.
             </ol>
             <li>
 Return <em>deskolemizedNquads</em>.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h4>toSkolemizedJSONLD</h4>
+
+          <p>
+The following algorithm converts an array of N-Quads to a skolemized
+JSON-LD document. The required inputs are an array of N-Quad strings
+(<var>inputNquads</var>). A JSON-LD document, <em>skolemizedJSONLD</em>, is
+produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `skolemizedQuads` to the result of calling <a href="#skolemize"></a>,
+with <var>inputNQuads</var> and "custom-scheme" as parameters. Implementations
+MAY choose a different <em>urnSchemeName</em> that is different than
+"custom-scheme" so long as the same scheme name is used in
+<a href="#toDeskolemizedRDF"></a> algorithm.
+            </li>
+            <li>
+Join `skolemizedQuads` into a single N-Quads string, `dataset`.
+            </li>
+            <li>
+Set <em>skolemizedJSONLD</em> to the result of the
+<a href="https://www.w3.org/TR/json-ld11-api/#serialize-rdf-as-json-ld-algorithm">
+Serialize RDF as JSON-LD</a> algorithm, passing any custom options (such as a
+document loader), to convert `dataset` from RDF to a JSON-LD document.
+            </li>
+            <li>
+Return <em>skolemizedJSONLD</em>.
             </li>
           </ol>
         </section>

--- a/index.html
+++ b/index.html
@@ -1871,6 +1871,97 @@ Return an object with "matching" set to `matching` and "nonMatching" set to
           </ol>
         </section>
 
+        <section>
+          <h4>filterAndGroupNquads</h4>
+
+          <p>
+The following algorithm filters N-Quads, given in an array of N-Quads and a
+JSON-LD filtering frame, and then groups the N-Quads that passed the filter into
+matching and non-matching groups based on another JSON-LD grouping frame. This
+function will internally perform skolemization and deskolemization around
+framing operations to ensure that any blank node identifiers do not change,
+which would prevent filtering and matching operations from working properly. The
+inputs to the algorithm are an array of N-Quads (<var>nquads</var>), a JSON-LD
+filtering frame (<var>filterFrame</var>), a JSON-LD grouping frame
+(<var>groupFrame</var>). Additionally, any custom JSON-LD API options are
+expected to be given as an input. An object containing two properties is
+provided as output; <em>matching</em> and <em>nonmatching</em> each hold arrays
+of their associated N-Quads.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `skolemizedDocument` to the result of calling the algorithm in
+Section <a href="#toskolemizedjsonld"></a>, passing `nquads` and any custom
+JSON-LD API options (such as a document loader).
+            </li>
+            <li>
+Initialize `filteredDocument` to the result of calling the algorithm in Section
+<a href="#strictframe"></a>, passing `skolemizedDocument`, `filterFrame`, and
+any custom JSON-LD API options.
+            </li>
+            <li>
+Initialize `filteredNQuads` to the result of calling the algorithm in Section <a
+href="#todeskolemizedrdf"></a>, passing `filteredDocument` and any custom
+JSON-LD API options.
+            </li>
+            <li>
+Note: These next two steps can be performed in parallel.
+            </li>
+            <ol class="algorithm">
+              <li>
+Get the canonical blank node identifier map, `canonicalIdMap`, by calling
+[[RDF-CANON]], passing the joined `filteredNQuads`. Canonicalize `filteredNQuads
+Note: These two steps can be performed in parallel.
+              </li>
+              <li>
+Get the `groupResult` by calling the algorithm in Section
+<a href="#groupnquads"></a>, passing `filteredNQuads`, `filteredDocument`,
+`groupFrame`, and any custom JSON-LD API options.
+              </li>
+            </ol>
+            <li>
+Note: Next generate matching and non-matching maps composed of original indexes
+to original N-Quads. The `groupResult` is different; it contains matching and
+non-matching maps using the `filteredNQuads` indexes. Both maps of indexes are
+useful to callers.
+            </li>
+            <li>
+Initialize `matching` to a new map.
+            </li>
+            <li>
+Initialize `nonMatching` to a new map.
+            </li>
+            <li>
+Initialize filteredMatches to the values in `groupResult.matching`.
+            </li>
+            <li>
+Initialize filteredNonMatches to the values in `groupResult.nonMatching`.
+            </li>
+            <li>
+For each entry (`index`, `nq`) in `nquads`:
+              <ol class="algorithm">
+                <li>
+If `filteredMatches` includes `nq` then add the entry to `matching`.
+                </li>
+                <li>
+Otherwise, if `filteredNonMatching` includes `nq` then add the entry to
+`nonMatching`.
+                </li>
+              </ol>
+            </li>
+            <li>
+Initialize `labelMap` to the reverse of `canonicalIdMap`. `labelMap` uses
+canonical blank node identifiers as keys and original blank node identifiers as
+values.
+            </li>
+            <li>
+Return an object with "filtered" set to `groupResult`, "labelMap" set to
+`labelMap`, "matching" to `matching`, and "nonMatching" to `nonMatching`.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1591,6 +1591,45 @@ Return `paths`.
           </ol>
         </section>
 
+        <section>
+          <h4>jsonPointerToPaths</h4>
+
+          <p>
+The following algorithm converts a JSON Pointer [[RFC6901]] to an array of paths
+into a JSON tree. The required input is a JSON Pointer string
+(<var>pointer</var>). An array of paths (<em>paths</em>) is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `paths` to an empty array.
+            </li>
+            <li>
+Initialize `splitPath` to an array by splitting <var>pointer</var> on the
+"/" character and skipping the first, empty, split element. In Javascript
+notation, this step is equivalent to the following code:
+`pointer.split('/').slice(1)`
+            </li>
+            <li>
+For each `path` in `splitPath`:
+              <ol class="algorithm">
+                <li>
+If `path` does not include `~`, then add `path` to `paths`, converting it to
+an integer if it parses as one, leaving it as a string if it does not.
+                </li>
+                <li>
+Otherwise, unescape any JSON pointer escape sequences in `path` and add the
+result to `paths`.
+                </li>
+              </ol>
+            </li>
+            <li>
+Return `paths`.
+            </li>
+          </ol>
+        </section>
+
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1553,6 +1553,44 @@ Return <em>outputNquads</em>.
           </ol>
         </section>
 
+        <section>
+          <h4>jsonPointerToPaths</h4>
+
+          <p>
+The following algorithm converts a JSON Pointer [[RFC6901]] to an array of paths
+into a JSON tree. The required input is a JSON Pointer string
+(<var>pointer</var>). An array of paths (<em>paths</em>) is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `paths` to an empty array.
+            </li>
+            <li>
+Initialize `splitPath` to an array by splitting <var>pointer</var> on the
+"/" character and skipping the first, empty, split element. In Javascript
+notation, this step is equivalent to the following code:
+`pointer.split('/').slice(1)`
+            </li>
+            <li>
+For each `path` in `splitPath`:
+              <ol class="algorithm">
+                <li>
+If `path` does not include `~`, then add `path` to `paths`, converting it to
+an integer if it parses as one, leaving it as a string if it does not.
+                </li>
+                <li>
+Otherwise, unescape any JSON pointer escape sequences in `path` and add the
+result to `paths`.
+                </li>
+              </ol>
+            </li>
+            <li>
+Return `paths`.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1390,6 +1390,7 @@ schemes such as BBS.
           </p>
 
         </section>
+
         <section>
           <h4>labelMapCanonize</h4>
 
@@ -1409,7 +1410,41 @@ reverse of <var>labelMap</var>.
 Return <em>labelMapReplacementFunction</em>.
             </li>
           </ol>
+        </section>
 
+        <section>
+          <h4>skolemize</h4>
+
+          <p>
+The following algorithm replaces all blank node identifiers in an array of
+N-Quad statements with a URN. The required inputs are an array of N-Quad strings
+(<var>inputNquads</var>) and a URN scheme (<var>urnScheme</var>). An array of
+N-Quad strings, <em>skolemizedNquads</em>, is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Create a new array of N-Quad strings, <em>skolemizedNquads</em>.
+            </li>
+            <li>
+For each N-Quad string, <em>s1</em>, in the input array:
+            <ol class="algorithm">
+              <li>
+Create a new string, <em>s2</em>, that is a copy of <em>s1</em> replacing any
+occurrence of a blank node identifier with a URN ("urn:"), plus the input
+custom scheme (<var>urnScheme</var>), plus a colon (":"), and
+the value of the blank node identifier. For example, a regular expression
+of a similar form to the following would achieve the desired result:
+<code>s1.replace(/(_:([^\s]+))/g, '&lt;urn:custom-scheme:$2>')</code>.
+              </li>
+              <li>
+Append <em>s2</em> to <em>skolemizedNquads</em>.
+              </li>
+            </ol>
+            <li>
+Return <em>skolemizedNquads</em>.
+            </li>
+          </ol>
         </section>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -1499,7 +1499,7 @@ Initialize `skolemizedQuads` to the result of calling <a href="#skolemize"></a>,
 with <var>inputNQuads</var> and "custom-scheme" as parameters. Implementations
 MAY choose a different <em>urnSchemeName</em> that is different than
 "custom-scheme" so long as the same scheme name is used in
-<a href="#toDeskolemizedRDF"></a> algorithm.
+<a href="#todeskolemizedrdf"></a> algorithm.
             </li>
             <li>
 Join `skolemizedQuads` into a single N-Quads string, `dataset`.
@@ -1512,6 +1512,42 @@ document loader), to convert `dataset` from RDF to a JSON-LD document.
             </li>
             <li>
 Return <em>skolemizedJSONLD</em>.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h4>toDeskolemizedRDF</h4>
+
+          <p>
+The following algorithm converts a skolemized JSON-LD document, such as one
+created using the Section <a href="#toskolemizedjsonld"></a> algorithm, to array of
+deskolemized N-Quads. The required inputs are a JSON-LD document,
+<em>skolemizedJSONLD</em>. An array of deskolemized N-Quad strings
+(<var>outputNquads</var>) is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `skolemizedDataset` to the result of calling the
+<a href="https://www.w3.org/TR/json-ld11-api/#deserialize-json-ld-to-rdf-algorithm">
+Deserialize JSON-LD to RDF</a> algorithm, passing any custom options (such as a
+document loader), to convert `skolemizedJSONLD` from JSON-LD to RDF in N-Quads
+format.
+            </li>
+            <li>
+Split `skolemizedDataset` into an array of individual N-Quads,
+`skolemizedNquads`.
+            </li>
+            <li>
+Set <var>outputNquads</var> to the result of calling the
+<a href="#deskolemize"></a> with `skolemizedNquads` and and "custom-scheme" as
+parameters. Implementations MAY choose a different <em>urnSchemeName</em> that
+is different than "custom-scheme" so long as the same scheme name is used in
+<a href="#toskolemizedjsonld"></a> algorithm.
+            </li>
+            <li>
+Return <em>outputNquads</em>.
             </li>
           </ol>
         </section>

--- a/index.html
+++ b/index.html
@@ -1661,6 +1661,120 @@ Return <em>frame</em>.
           </ol>
         </section>
 
+        <section>
+          <h4>jsonPointersToFrame</h4>
+
+          <p>
+The following algorithm converts an array of JSON Pointers and a JSON-LD
+document to a JSON-LD Frame to be used on that specific document. The required
+input is an array of JSON Pointers (<var>pointers</var>) and a JSON-LD document
+(<var>document</var>). A JSON-LD frame (<em>frame</em>) is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If `pointers` is empty, return `null`.
+            </li>
+            <li>
+Initialize `frame` to an initial frame passing `document` as `value` to
+"createInitialFrame".
+            </li>
+            <li>
+For each `pointer` in `pointers` walk the document from root to the pointer
+target value building the frame:
+            </li>
+            <ol class="algorithm">
+              <li>
+Initialize `parentFrame` to `frame`.
+              </li>
+              <li>
+Initialize `parentValue` to `document`.
+              </li>
+              <li>
+Initialize `value` to `parentValue`.
+              </li>
+              <li>
+Initialize `valueFrame` to `parentFrame`.
+              </li>
+              <li>
+Parse the `pointer` into an array of `paths` using "pointerToPaths".
+              </li>
+              <li>
+For each `path` in `paths:
+              </li>
+              <ol class="algorithm">
+                <li>
+Set `parentFrame` to `valueFrame`.
+                </li>
+                <li>
+Set `parentValue` to `value`.
+                </li>
+                <li>
+Set `value` to `parentValue[path]`. If `value` is now undefined, throw an error
+indicating that the JSON pointer does not match the given `document`.
+                </li>
+                <li>
+Set `valueFrame` to `parentFrame[path]`.
+                </li>
+                <li>
+If `valueFrame` is undefined:
+                </li>
+                <ol class="algorithm">
+                  <li>
+If `value` is an array, set `valueFrame` to an empty array.
+                  </li>
+                  <li>
+Otherwise, set `valueFrame` to an initial frame passing `value` to
+"createInitialFrame".
+                  </li>
+                  <li>
+Set `parentFrame[path]` to `valueFrame`.
+                  </li>
+                </ol>
+              </ol>
+              <li>
+Note: Next we generate the final `valueFrame`.
+              </li>
+              <li>
+If `value` is not an object, then a literal has been selected: Set `valueFrame`
+to `value`.
+              </li>
+              <li>
+Otherwise, if `value` is an array: Set `valueFrame` to the result of mapping
+every element in `value` to a deep copy of itself. If any element in `value` is
+also an `array`, throw an error indicating that arrays of arrays are not
+supported.
+              </li>
+              <li>
+Otherwise: Set `valueFrame` to an object that merges a shallow copy of
+`valueFrame` with a deep copy of `value`, e.g., `{...valueFrame,
+&hellip;deepCopy(value)}`.
+              </li>
+              <li>
+If `paths` has a length of zero, then the whole `document` has been selected by
+the `pointer`: Set `frame` to `valueFrame`.
+              </li>
+              <li>
+Otherwise, a partial selection has been made by the pointer:
+                <ol class="algorithm">
+                  <li>
+Get the last `path`, `lastPath`, from `paths`.
+                  </li>
+                  <li>
+Set `parentFrame[lastPath]` to `valueFrame`.
+                  </li>
+                </ol>
+              <li>
+Set `frame['@context']` to a deep copy of `document['@context']`.
+              </li>
+              <li>
+Return `frame`.
+              </li>
+            </ol>
+          </ol>
+
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1495,11 +1495,12 @@ produced as output.
 
           <ol class="algorithm">
             <li>
-Initialize `skolemizedQuads` to the result of calling <a href="#skolemize"></a>,
-with <var>inputNQuads</var> and "custom-scheme" as parameters. Implementations
-MAY choose a different <em>urnSchemeName</em> that is different than
-"custom-scheme" so long as the same scheme name is used in
-<a href="#todeskolemizedrdf"></a> algorithm.
+Initialize `skolemizedQuads` to the result of calling the algorithm in
+Section <a href="#skolemize"></a>, with <var>inputNQuads</var> and
+"custom-scheme" as parameters. Implementations MAY choose a different
+<em>urnSchemeName</em> that is different than "custom-scheme" so long as the
+same scheme name is used in the algorithm in Section
+<a href="#todeskolemizedrdf"></a>.
             </li>
             <li>
 Join `skolemizedQuads` into a single N-Quads string, `dataset`.
@@ -1521,8 +1522,8 @@ Return <em>skolemizedJSONLD</em>.
 
           <p>
 The following algorithm converts a skolemized JSON-LD document, such as one
-created using the Section <a href="#toskolemizedjsonld"></a> algorithm, to array of
-deskolemized N-Quads. The required inputs are a JSON-LD document,
+created using the algorithm in Section <a href="#toskolemizedjsonld"></a>, to an
+array of deskolemized N-Quads. The required inputs are a JSON-LD document,
 <em>skolemizedJSONLD</em>. An array of deskolemized N-Quad strings
 (<var>outputNquads</var>) is produced as output.
           </p>
@@ -1540,11 +1541,11 @@ Split `skolemizedDataset` into an array of individual N-Quads,
 `skolemizedNquads`.
             </li>
             <li>
-Set <var>outputNquads</var> to the result of calling the
-<a href="#deskolemize"></a> with `skolemizedNquads` and and "custom-scheme" as
+Set <var>outputNquads</var> to the result of calling the algorithm in Section
+<a href="#deskolemize"></a> with `skolemizedNquads` and "custom-scheme" as
 parameters. Implementations MAY choose a different <em>urnSchemeName</em> that
 is different than "custom-scheme" so long as the same scheme name is used in
-<a href="#toskolemizedjsonld"></a> algorithm.
+the algorithm in Section <a href="#toskolemizedjsonld"></a>.
             </li>
             <li>
 Return <em>outputNquads</em>.

--- a/index.html
+++ b/index.html
@@ -1020,6 +1020,333 @@ Return <var>verificationResult</var> as the <em>verification result</em>.
 
         </section>
       </section>
+      <section>
+        <h3>jcs-ecdsa-2019</h3>
+
+        <p>
+The `jcs-ecdsa-2019` cryptographic suite takes an input document, canonicalizes
+the document using the JSON Canonicalization Scheme [[RFC8785]], and then
+cryptographically hashes and signs the output
+resulting in the production of a data integrity proof. The algorithms in this
+section also include the verification of such a data integrity proof.
+        </p>
+
+        <section>
+          <h4>Add Proof (jcs-ecdsa-2019)</h4>
+
+          <p>
+To generate a proof, the algorithm in
+<a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
+Section 4.1: Add Proof</a> of the Data Integrity
+[[VC-DATA-INTEGRITY]] specification MUST be executed.
+For that algorithm, the cryptographic suite-specific
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
+transformation algorithm</a> is defined in Section
+<a href="#transformation-jcs-ecdsa-2019"></a>, the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
+hashing algorithm</a> is defined in Section <a href="#hashing-jcs-ecdsa-2019"></a>,
+and the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
+proof serialization algorithm</a> is defined in Section
+<a href="#proof-serialization-jcs-ecdsa-2019"></a>.
+          </p>
+        </section>
+
+        <section>
+          <h4>Verify Proof (jcs-ecdsa-2019)</h4>
+
+          <p>
+To verify a proof, the algorithm in
+<a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
+Section 4.2: Verify Proof</a> of the Data Integrity
+[[VC-DATA-INTEGRITY]] specification MUST be executed.
+For that algorithm, the cryptographic suite-specific
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
+transformation algorithm</a> is defined in Section
+<a href="#transformation-jcs-ecdsa-2019"></a>, the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
+hashing algorithm</a> is defined in Section <a href="#hashing-jcs-ecdsa-2019"></a>,
+and the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
+proof verification algorithm</a> is defined in Section
+<a href="#proof-verification-jcs-ecdsa-2019"></a>.
+          </p>
+        </section>
+
+        <section>
+          <h4>Transformation (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to transform an unsecured input document
+into a transformed document that is ready to be provided as input to the
+hashing algorithm in Section <a href="#hashing-jcs-ecdsa-2019"></a>.
+          </p>
+
+          <p>
+Required inputs to this algorithm are an
+<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
+unsecured data document</a> (<var>unsecuredDocument</var>) and
+transformation options (<var>options</var>). The
+transformation options MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and a cryptosuite
+identifier (<var>cryptosuite</var>). A <em>transformed data document</em> is
+produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
+encoding.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If <var>options</var>.<var>type</var> is not set to the string
+`DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
+set to the string `jcs-ecdsa-2019`, then a `PROOF_TRANSFORMATION_ERROR` MUST be
+raised.
+            </li>
+            <li>
+Let <var>canonicalDocument</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
+            </li>
+            <li>
+Set <var>output</var> to the value of <var>canonicalDocument</var>.
+            </li>
+            <li>
+Return <var>canonicalDocument</var> as the <em>transformed data document</em>.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h4>Hashing (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to cryptographically hash a
+<em>transformed data document</em> and <em>proof configuration</em>
+into cryptographic hash data that is ready to be provided as input to the
+algorithms in Section <a href="#proof-serialization-jcs-ecdsa-2019"></a> or
+Section <a href="#proof-verification-jcs-ecdsa-2019"></a>. One must use the
+hash algorithm appropriate in security level to the curve used, i.e., for curve
+P-256 one uses SHA-256, and for curve P-384 one uses SHA-384.
+          </p>
+
+          <p>
+The required inputs to this algorithm are a <em>transformed data document</em>
+(<var>transformedDocument</var>) and a <em>canonical proof configuration</em>
+(<var>canonicalProofConfig</var>). A single <em>hash data</em> value represented as
+series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>transformedDocumentHash</var> be the result of applying the SHA-256
+(SHA-2 with 256-bit output) or SHA-384 (SHA-2 with 384-bit output)
+cryptographic hashing algorithm [[RFC6234]] to the
+respective curve P-256 or curve P-384 <var>transformedDocument</var>.
+Respective <var>transformedDocumentHash</var> will be exactly 32 or 48 bytes
+in size.
+            </li>
+            <li>
+Let <var>proofConfigHash</var> be the result of applying the SHA-256
+(SHA-2 with 256-bit output) or SHA-384 (SHA-2 with 384-bit output)
+cryptographic hashing algorithm [[RFC6234]] to the
+respective curve P-256 or curve P-384 <var>canonicalProofConfig</var>.
+Respective <var>proofConfigHash</var> will be exactly 32 or 48 bytes in size.
+            </li>
+            <li>
+Let <var>hashData</var> be the result of concatenating <var>proofConfigHash</var> (the
+first hash) followed by <var>transformedDocumentHash</var> (the second hash).
+            </li>
+            <li>
+Return <var>hashData</var> as the <em>hash data</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Configuration (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to generate a
+<em>proof configuration</em> from a set of <em>proof options</em>
+that is used as input to the <a href="#hashing-jcs-ecdsa-2019">proof hashing algorithm</a>.
+          </p>
+
+          <p>
+The required inputs to this algorithm are <em>proof options</em>
+(<var>options</var>). The <em>proof options</em> MUST contain a type identifier
+for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and MUST contain a cryptosuite
+identifier (<var>cryptosuite</var>). A <em>proof configuration</em>
+object is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>proofConfig</var> be an empty object.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>type</var> to
+<var>options</var>.<var>type</var>.
+            </li>
+            <li>
+If <var>options</var>.<var>cryptosuite</var> is set, set
+<var>proofConfig</var>.<var>cryptosuite</var> to its value.
+            </li>
+            <li>
+If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
+<var>proofConfig</var>.<var>cryptosuite</var> is not set to `jcs-ecdsa-2019`, an
+`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>created</var> to
+<var>options</var>.<var>created</var>. If the value is not a valid
+[[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>verificationMethod</var> to
+<var>options</var>.<var>verificationMethod</var>.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>proofPurpose</var> to
+<var>options</var>.<var>proofPurpose</var>.
+            </li>
+            <li>
+Let <var>canonicalProofConfig</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
+            </li>
+            <li>
+Return <var>canonicalProofConfig</var>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Serialization (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to serialize a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (<var>hashData</var>) and
+<em>proof options</em> (<var>options</var>). The
+<em>proof options</em> MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and MAY contain a cryptosuite
+identifier (<var>cryptosuite</var>). A single <em>digital proof</em> value
+represented as series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>privateKeyBytes</var> be the result of retrieving the
+private key bytes associated with the
+<var>options</var>.<var>verificationMethod</var> value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Retrieving Cryptographic Material</a>.
+            </li>
+            <li>
+Let <var>proofBytes</var> be the result of applying the Elliptic Curve Digital
+Signature Algorithm (ECDSA) [[FIPS-186-5]], with <var>hashData</var> as the data
+to be signed using the private key specified by <var>privateKeyBytes</var>.
+<var>proofBytes</var> will be exactly 64 bytes in size for a P-256 key, and
+96 bytes in size for a P-384 key.
+            </li>
+            <li>
+Return <var>proofBytes</var> as the <em>digital proof</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Verification (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to verify a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (<var>hashData</var>),
+a digital signature (<var>proofBytes</var>), and
+proof options (<var>options</var>). A <em>verification result</em>
+represented as a boolean value is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>publicKeyBytes</var> be the result of retrieving the
+public key bytes associated with the
+<var>options</var>.<var>verificationMethod</var> value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Retrieving Cryptographic Material</a>.
+            </li>
+            <li>
+Let <var>verificationResult</var> be the result of applying the verification
+algorithm, Elliptic Curve Digital Signature Algorithm (ECDSA) [[FIPS-186-5]],
+with <var>hashData</var> as the data to be verified against the
+<var>proofBytes</var> using the public key specified by
+<var>publicKeyBytes</var>.
+            </li>
+            <li>
+Return <var>verificationResult</var> as the <em>verification result</em>.
+            </li>
+          </ol>
+
+        </section>
+      </section>
+
+      <section>
+        <h4>Selective Disclosure Primitives</h4>
+
+        <p>
+The following section contains a set of functions that are used throughout
+cryptographic suites that perform selective disclosure.
+        </p>
+
+        <section>
+          <h4>labelReplacementCanonize</h4>
+
+          <p>
+The following algorithm canonizes a JSON-LD document and replaces any blank node
+identifiers in the canonicalized document by applying a label replacement
+function, <var>labelReplacementFunction</var>. The required inputs are a JSON-LD
+document (<var>document</var>) and a label replacement functon
+(</var>labelReplacementFunction<var>). A N-Quads representation of the
+<em>canonized result</em>, with the replaced blank node labels, and a map from
+the old blank node IDs to the new blank node IDs, <em>map</em> is produced as
+output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Run the RDF Dataset Canonicalization Algorithm [[RDFC-1.0]] on
+<var>document</var>, passing any custom options (such as a document loader), and
+get the canonicalized dataset as output, which includes a canonical bnode
+identifier map, <var>canonicalIdMap</var>.
+            </li>
+            <li>
+Pass <var>canonicalIdMap</var> to <var>labelReplacementFunction</var> to produce
+a new bnode identifier map, <em>bnodeIdMap</em>.
+            </li>
+            <li>
+Produce canonical N-Quads representation, <em>canonized result</em>, using
+canonicalized dataset along with <em>bnodeIdMap</em> and return it.
+            </li>
+          </ol>
+
+        </section>
+
+      </section>
+
     </section>
     <section class="informative">
       <h2>Security Considerations</h2>

--- a/index.html
+++ b/index.html
@@ -1924,6 +1924,31 @@ Return an object with "filtered" set to `groupResult`, "labelMap" set to
           </ol>
         </section>
 
+        <section>
+          <h4>hashMandatoryNQuads</h4>
+
+          <p>
+The following algorithm cryptographically hashes an array of mandatory to
+disclose N-Quads using a provided hashing API. The required input is an array of
+mandatory to disclose N-Quads (<var>mandatory</var>) and a hashing function
+(<var>hasher</var>). A cryptographic hash (<em>mandatoryHash</em>) is produced
+as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `bytes` to the UTF-8 representation of the joined `mandatory`
+N-Quads.
+            </li>
+            <li>
+Initialize `mandatoryHash` to the result of using `hasher` to hash `bytes`.
+            </li>
+            <li>
+Return `mandatoryHash`.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1592,44 +1592,6 @@ Return `paths`.
         </section>
 
         <section>
-          <h4>jsonPointerToPaths</h4>
-
-          <p>
-The following algorithm converts a JSON Pointer [[RFC6901]] to an array of paths
-into a JSON tree. The required input is a JSON Pointer string
-(<var>pointer</var>). An array of paths (<em>paths</em>) is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Initialize `paths` to an empty array.
-            </li>
-            <li>
-Initialize `splitPath` to an array by splitting <var>pointer</var> on the
-"/" character and skipping the first, empty, split element. In Javascript
-notation, this step is equivalent to the following code:
-`pointer.split('/').slice(1)`
-            </li>
-            <li>
-For each `path` in `splitPath`:
-              <ol class="algorithm">
-                <li>
-If `path` does not include `~`, then add `path` to `paths`, converting it to
-an integer if it parses as one, leaving it as a string if it does not.
-                </li>
-                <li>
-Otherwise, unescape any JSON pointer escape sequences in `path` and add the
-result to `paths`.
-                </li>
-              </ol>
-            </li>
-            <li>
-Return `paths`.
-            </li>
-          </ol>
-        </section>
-
-        <section>
           <h4>createInitialFrame</h4>
 
           <p>

--- a/index.html
+++ b/index.html
@@ -1320,10 +1320,10 @@ The following algorithm canonizes a JSON-LD document and replaces any blank node
 identifiers in the canonicalized document by applying a label replacement
 function, <var>labelReplacementFunction</var>. The required inputs are a JSON-LD
 document (<var>document</var>) and a label replacement functon
-(</var>labelReplacementFunction<var>). A N-Quads representation of the
+(<var>labelReplacementFunction</var>). A N-Quads representation of the
 <em>canonized result</em>, with the replaced blank node labels, and a map from
-the old blank node IDs to the new blank node IDs, <em>map</em> is produced as
-output.
+the old blank node IDs to the new blank node IDs, <em>bnodeIdMap</em>, is
+produced as output.
           </p>
 
           <ol class="algorithm">
@@ -1342,6 +1342,52 @@ Produce canonical N-Quads representation, <em>canonized result</em>, using
 canonicalized dataset along with <em>bnodeIdMap</em> and return it.
             </li>
           </ol>
+
+        </section>
+
+        <section>
+          <h4>hmacIdCanonize</h4>
+
+          <p>
+The following algorithm creates a label replacement function that uses an
+HMAC to replace canonical blank node identifiers with their encoded HMAC
+digests. The required inputs are a canonical node identifier map,
+<var>canonicalIdMap</var>. A blank node identifier map, <em>bnodeIdMap</em>, is
+produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Generate a new empty bnode identifier map, <em>bnodeIdMap</em>.
+            </li>
+            <li>
+For each map entry in <var>canonicalIdMap</var>:
+              <ol class="algorithm">
+                <li>
+HMAC the canonical identifier from the entry to get an HMAC digest,
+<em>digest</em>.
+                </li>
+                <li>
+Generate a new string value, <em>b64urlDigest</em>, and initialize it to "u"
+followed by appending a base64url-no-pad encoded version of the <em>digest</em>
+value.
+                </li>
+                <li>
+Add this new entry to <em>bnodeIdMap</em>.
+                </li>
+              </ol>
+            </li>
+            <li>
+Return <em>bnodeIdMap</em>.
+            </li>
+          </ol>
+
+          <p class="note" title="Other algorithms are possible">
+A different primitive could be created that sorted the resulting HMAC digests
+and assigned labels using a prefix and integers based on their sorted order
+instead. This primitive might be useful for index-based selective disclosure
+schemes such as BBS.
+          </p>
 
         </section>
 

--- a/index.html
+++ b/index.html
@@ -1629,6 +1629,37 @@ Return `paths`.
           </ol>
         </section>
 
+        <section>
+          <h4>createInitialFrame</h4>
+
+          <p>
+The following algorithm creates an initial JSON-LD frame based on a JSON-LD
+object. This is a helper function used within the algorithm in
+Section <a href="#jsonpointerstoframe"></a>. The required input is a
+JSON-LD object (<var>value</var>). A JSON-LD frame <em>frame</em> is produced
+as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize <em>frame</em> to an empty object.
+            </li>
+            <li>
+If <var>value</var> has an `id` that is not a blank node identifier, set
+`frame.id` to its value. Note: All non-blank node identifiers in the path of
+any JSON Pointer MUST be included in the frame, this includes any root document
+identifier.
+            </li>
+            <li>
+If <var>value</var>.`type` is set, set <em>frame</em>.`type` to its value.
+Note: All `type`s in the path of any JSON Pointer MUST be included in the frame,
+this includes any root document `type`.
+            </li>
+            <li>
+Return <em>frame</em>.
+            </li>
+          </ol>
+        </section>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@ match the verification relationship expressed by the verification method
           <p>
 The `proofValue` property of the proof MUST be an ECDSA or deterministic ECDSA
 signature produced according to [[FIPS-186-5]] using the curves and hashes as
-specified in section <a href="#algorithms"></a>, encoded according to section 7 
+specified in section <a href="#algorithms"></a>, encoded according to section 7
 of [[RFC4754]] (sometimes referred to as the IEEE P1363 format), and serialized
 according to [[MULTIBASE]] using the base58-btc base encoding.
           </p>

--- a/index.html
+++ b/index.html
@@ -1775,6 +1775,30 @@ Return `frame`.
           </ol>
         </section>
 
+        <section>
+          <h4>strictFrame</h4>
+
+          <p>
+The following algorithm performs a JSON-LD framing operation on a JSON-LD
+document with strict framing options. The required inputs are a JSON-LD Document
+(<var>document</var>) and a JSON-LD Frame (<var>frame</var>). A JSON-LD document
+(<em>framedDocument</em>) is generated as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Set <em>framedDocument</em> to the result of the
+<a href="https://www.w3.org/TR/json-ld11-framing/#framing">
+JSON-LD Framing algorithm</a>, passing `document` and `frame`, and setting the
+options `requireAll`, `explicit`, and `omitGraph` to `true`. Any additional
+custom options passed, such as a document loader, is included as well.
+            </li>
+            <li>
+Return <em>framedDocument</em>.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1390,6 +1390,27 @@ schemes such as BBS.
           </p>
 
         </section>
+        <section>
+          <h4>labelMapCanonize</h4>
+
+          <p>
+The following algorithm creates a label replacement function that uses a label
+map to replace canonical blank node identifiers with the associated value from
+the labeel map. The required inputs are a label map, <var>labelMap</var>. A
+function, <em>labelMapReplacementFunction</em>, is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Set <em>labelMapReplacementFunction</em> to a function that returns the
+reverse of <var>labelMap</var>.
+            </li>
+            <li>
+Return <em>labelMapReplacementFunction</em>.
+            </li>
+          </ol>
+
+        </section>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1447,6 +1447,43 @@ Return <em>skolemizedNquads</em>.
           </ol>
         </section>
 
+
+        <section>
+          <h4>deskolemize</h4>
+
+          <p>
+The following algorithm replaces all custom scheme URNs in an array of
+N-Quad statements with a blank node identifier. The required inputs are an array of N-Quad strings
+(<var>inputNquads</var>) and a URN scheme (<var>urnScheme</var>). An array of
+N-Quad strings, <em>deskolemizedNquads</em>, is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Create a new array of N-Quad strings, <em>deskolemizedNquads</em>.
+            </li>
+            <li>
+For each N-Quad string, <em>s1</em>, in the <var>inputNquads</var> array:
+            <ol class="algorithm">
+              <li>
+Create a new string, <em>s2</em>, that is a copy of <em>s1</em> replacing any
+occurrence of a URN ("urn:"), plus the input
+custom scheme (<var>urnScheme</var>), plus a colon (":"), and
+the value of the blank node identifier with a blank node prefix ("_:"), plus
+the value of the blank node identifier. For example, a regular expression
+of a similar form to the following would achieve the desired result:
+<code>s1.replace(/(&lt;urn:custom-scheme:([^>]+)>)/g, '_:$2').</code>.
+              </li>
+              <li>
+Append <em>s2</em> to <em>deskolemizedNquads</em>.
+              </li>
+            </ol>
+            <li>
+Return <em>deskolemizedNquads</em>.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1799,6 +1799,78 @@ Return <em>framedDocument</em>.
           </ol>
         </section>
 
+        <section>
+          <h4>groupNquads</h4>
+
+          <p>
+The following algorithm groups N-Quads into matching and non-matching groups.
+The inputs are an array of N-Quads (<var>nquads</var>, an optional skolemized
+JSON-LD document (<var>skolemizedDocument</var>), an optional JSON-LD frame
+(<var>frame</var>) , and any options, such as a document loader, to be passed to
+JSON-LD APIs. Each of the output groups (matching and non-matching) are
+expressed as a map that maps an index into <var>nquads<var> to the N-Quad value.
+This algorithm uses a JSON-LD frame to match specific N-Quads in the array of
+given <var>nquads</var>. It internally skolemizes and then deskolemizes any
+blank nodes around the framing operation to ensure blank node identifiers do not
+change, preventing the matching operation from working properly.
+An object containing a <em>matching</em> and <em>nonmatching</em> arrays of
+N-Quads are generated as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `matching` to an empty map.
+            </li>
+            <li>
+Initialize `nonMatching` to an empty map.
+            </li>
+            <li>
+If `frame` is not given or `null`, then there are no matches so:
+              <ol class="algorithm">
+                <li>
+Add each entry (index, element) in `nquads` to `nonMatching`.
+                </li>
+                <li>
+Return an object with "matching" set to `matching` and "nonMatching" set to
+`nonMatching`.
+                </li>
+              </ol>
+            </li>
+            <li>
+If `skolemizedDocument` has not been given: Set `skolemizedDocument` to the
+result of calling "createSkolemizedDocument", passing `nquads` and any custom
+JSON-LD API options (such as a document loader).
+            </li>
+            <li>
+Initialize `framed` to the result of calling "strictFrame", passing
+`skolemizedDocument`, `frame`, and any custom JSON-LD API options. Note: This
+step filters the skolemized document to get only data that matches the frame as
+a new JSON-LD document.
+            </li>
+            <li>
+Initialize `matchingDeskolemized` to the result of calling "toDeskolemizedRDF",
+passing `framed` and any custom JSON-LD API options. Note: This step converts
+any matching data back to deskolemized N-Quads, matching their original
+expression.
+            </li>
+            <li>
+For each entry (`index`, `nq`) in `nquads`:
+              <ol class="algorithm">
+                <li>
+If `matchingDeskolemized` includes `nq`, add the entry to `matching`.
+                </li>
+                <li>
+Otherwise, add the entry to `nonMatching`.
+                </li>
+              </ol>
+            </li>
+            <li>
+Return an object with "matching" set to `matching` and "nonMatching" set to
+`nonMatching`.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1305,7 +1305,16 @@ Return <var>verificationResult</var> as the <em>verification result</em>.
       </section>
 
       <section>
-        <h4>Selective Disclosure Primitives</h4>
+        <h4>Selective Disclosure Functions</h4>
+
+        <p class="issue" title="(AT RISK) Pending implementation feedback and security reviews.">
+The Working Group is seeking implementer feedback on these generalized selective
+disclosure functions as well as horizonal security review on the features from
+parties at W3C and IETF. Those reviews might result in significant changes to
+these functions, migration of these functions to the core Data Integrity
+specification (for use by other cryptographic suites), or the removal of the
+algorithm from the specification during the Candidate Recommendation phase.
+        </p>
 
         <p>
 The following section contains a set of functions that are used throughout


### PR DESCRIPTION
This PR adds helper functions for performing selective disclosure to the ECDSA Data Integrity cryptosuite. These functions are more generally useful to other selective disclosure schemes, such as BBS, so we might want to eventually move these helper functions out to the vc-data-integrity specification.

This PR is raised as a result of stated support by W3C Members in this group, three global standards organizations (two of whom are members of the VCWG), and a number of implementers: https://lists.w3.org/Archives/Public/public-vc-wg/2023Jul/0015.html


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/pull/19.html" title="Last updated on Aug 3, 2023, 12:23 PM UTC (8aa04d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/19/9308063...8aa04d3.html" title="Last updated on Aug 3, 2023, 12:23 PM UTC (8aa04d3)">Diff</a>