### PR TITLE
Add ecdsa-sd-2023 cryptosuite to ECDSA Cryptosuites specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -2063,6 +2063,73 @@ series of bytes is produced as output.
 
         </section>
 
+        <section>
+          <h4>Proof Configuration (ecdsa-sd-2023)</h4>
+
+          <p>
+The following algorithm specifies how to generate a
+<em>proof configuration</em> from a set of <em>proof options</em>
+that is used as input to the <a href="#hashing-ecdsa-sd-2023">proof hashing algorithm</a>.
+          </p>
+
+          <p>
+The required inputs to this algorithm are <em>proof options</em>
+(<var>options</var>). The <em>proof options</em> MUST contain a type identifier
+for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and MUST contain a cryptosuite
+identifier (<var>cryptosuite</var>). A <em>proof configuration</em>
+object is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>proofConfig</var> be an empty object.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>type</var> to
+<var>options</var>.<var>type</var>.
+            </li>
+            <li>
+If <var>options</var>.<var>cryptosuite</var> is set, set
+<var>proofConfig</var>.<var>cryptosuite</var> to its value.
+            </li>
+            <li>
+If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
+<var>proofConfig</var>.<var>cryptosuite</var> is not set to `ecdsa-sd-2023`, an
+`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>created</var> to
+<var>options</var>.<var>created</var>. If the value is not a valid
+[[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>verificationMethod</var> to
+<var>options</var>.<var>verificationMethod</var>.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>proofPurpose</var> to
+<var>options</var>.<var>proofPurpose</var>.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>@context</var> to
+<var>unsecuredDocument</var>.<var>@context</var>.
+            </li>
+            <li>
+Let <var>canonicalProofConfig</var> be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the <var>proofConfig</var>.
+            </li>
+            <li>
+Return <var>canonicalProofConfig</var>.
+            </li>
+          </ol>
+
+        </section>
+
+      </section>
+
     </section>
     <section class="informative">
       <h2>Security Considerations</h2>

--- a/index.html
+++ b/index.html
@@ -1328,7 +1328,7 @@ produced as output.
 
           <ol class="algorithm">
             <li>
-Run the RDF Dataset Canonicalization Algorithm [[RDFC-1.0]] on
+Run the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] on
 <var>document</var>, passing any custom options (such as a document loader), and
 get the canonicalized dataset as output, which includes a canonical bnode
 identifier map, <var>canonicalIdMap</var>.
@@ -1677,7 +1677,7 @@ If `pointers` is empty, return `null`.
             </li>
             <li>
 Initialize `frame` to an initial frame passing `document` as `value` to
-"createInitialFrame".
+the algorithm in Section <a href="#createinitialframe"></a>.
             </li>
             <li>
 For each `pointer` in `pointers` walk the document from root to the pointer
@@ -1697,10 +1697,11 @@ Initialize `value` to `parentValue`.
 Initialize `valueFrame` to `parentFrame`.
               </li>
               <li>
-Parse the `pointer` into an array of `paths` using "pointerToPaths".
+Parse the `pointer` into an array of `paths` using the algorithm in
+Section <a href="#jsonpointertopaths"></a>.
               </li>
               <li>
-For each `path` in `paths:
+For each `path` in `paths`:
               </li>
               <ol class="algorithm">
                 <li>
@@ -1725,7 +1726,7 @@ If `value` is an array, set `valueFrame` to an empty array.
                   </li>
                   <li>
 Otherwise, set `valueFrame` to an initial frame passing `value` to
-"createInitialFrame".
+the algorithm in Section <a href="#createinitialframe"></a>.
                   </li>
                   <li>
 Set `parentFrame[path]` to `valueFrame`.
@@ -1772,7 +1773,6 @@ Return `frame`.
               </li>
             </ol>
           </ol>
-
         </section>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -2238,8 +2238,10 @@ Return `baseProof` as <em>base proof</em>.
           <h4>Base Proof Serialization (ecdsa-sd-2023)</h4>
 
           <p>
-The following algorithm specifies how to serialize a digital signature from
-a set of cryptographic hash data. This
+The following algorithm specifies how to create a base proof; called by an
+issuer of an ECDSA-SD-protected Verifiable Credential. The base proof is to be
+given only to the holder, who is responsible for generating a derived proof from
+it, exposing only selectively disclosed details in the proof to a verifier. This
 algorithm is designed to be used in conjunction with the algorithms defined
 in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
 <a data-cite="vc-data-integrity#algorithms">
@@ -2254,7 +2256,53 @@ represented as series of bytes is produced as output.
           </p>
 
           <ol class="algorithm">
-
+            <li>
+Initialize `proofHash`, `mandatoryPointers`, `mandatoryHash`, `nonMandatory`,
+and `hmacKey` to the values associated with their property names
+<var>hashData</var>.
+            </li>
+            <li>
+Initialize `proofScopedKeyPair` to a locally generated P-256 ECDSA key pair.
+Note: This key pair is scoped to the specific proof; it is not used for anything
+else and the private key will be destroyed when this algorithm terminates.
+            </li>
+            <li>
+Initialize `signatures` to an array where each element holds the result of
+digitally signing the UTF-8 representation of each N-Quad string in
+`nonMandatory`, in order. The digital signature algorithm is ES256, i.e., uses a
+P-256 curve over a SHA-256 digest, and uses the private key from
+`proofScopedKeyPair`. Note: This step generates individual signatures for each
+statement that can be selectively disclosed using a local, proof-scoped key pair
+that binds them together; this key pair will be bound to the proof by a
+signature over its public key using the private key associated with the base
+proof verification method.
+            </li>
+            <li>
+Initialize `publicKey` to the multikey expression of the public key exported
+from `proofScopedKeyPair`. That is, an array of bytes starting with the bytes
+0x80 and 0x24 (which is the multikey p256-pub header (0x1200) expressed as a
+varint) followed by the compressed public key bytes (the compressed header with
+`2` for an even `y` coordinate and `3` for an odd one followed by the `x`
+coordinate of the public key).
+            </li>
+            <li>
+Initialize `toSign` to the result of calling the algorithm in Section
+<a href="#serializebasesigndata"></a>, passing `proofHash`, `publicKey`, and
+`mandatoryHash` as parameters to the algorithm.
+            </li>
+            <li>
+Initialize `baseSignature` to the result of digitally signing `toSign` using the
+private key associated with the base proof verification method.
+            </li>
+            <li>
+Initialize `proofValue to the result of calling the algorithm in Section
+<a href="#serializebaseproofvalue"></a>, passing `baseSignature`,
+`publicKey`, `hmacKey`, `signatures`, and `mandatoryPointers` as parameters
+to the algorithm.
+            </li>
+            <li>
+Return `proofValue` as <em>digital proof</em>.
+            </li>
           </ol>
 
         </section>

--- a/index.html
+++ b/index.html
@@ -1447,7 +1447,6 @@ Return <em>skolemizedNquads</em>.
           </ol>
         </section>
 
-
         <section>
           <h4>deskolemize</h4>
 
@@ -1480,6 +1479,39 @@ Append <em>s2</em> to <em>deskolemizedNquads</em>.
             </ol>
             <li>
 Return <em>deskolemizedNquads</em>.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h4>toSkolemizedJSONLD</h4>
+
+          <p>
+The following algorithm converts an array of N-Quads to a skolemized
+JSON-LD document. The required inputs are an array of N-Quad strings
+(<var>inputNquads</var>). A JSON-LD document, <em>skolemizedJSONLD</em>, is
+produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `skolemizedQuads` to the result of calling <a href="#skolemize"></a>,
+with <var>inputNQuads</var> and "custom-scheme" as parameters. Implementations
+MAY choose a different <em>urnSchemeName</em> that is different than
+"custom-scheme" so long as the same scheme name is used in
+<a href="#toDeskolemizedRDF"></a> algorithm.
+            </li>
+            <li>
+Join `skolemizedQuads` into a single N-Quads string, `dataset`.
+            </li>
+            <li>
+Set <em>skolemizedJSONLD</em> to the result of the
+<a href="https://www.w3.org/TR/json-ld11-api/#serialize-rdf-as-json-ld-algorithm">
+Serialize RDF as JSON-LD</a> algorithm, passing any custom options (such as a
+document loader), to convert `dataset` from RDF to a JSON-LD document.
+            </li>
+            <li>
+Return <em>skolemizedJSONLD</em>.
             </li>
           </ol>
         </section>

--- a/index.html
+++ b/index.html
@@ -1871,6 +1871,97 @@ Return an object with "matching" set to `matching` and "nonMatching" set to
           </ol>
         </section>
 
+        <section>
+          <h4>filterAndGroupNquads</h4>
+
+          <p>
+The following algorithm filters N-Quads, given in an array of N-Quads and a
+JSON-LD filtering frame, and then groups the N-Quads that passed the filter into
+matching and non-matching groups based on another JSON-LD grouping frame. This
+function will internally perform skolemization and deskolemization around
+framing operations to ensure that any blank node identifiers do not change,
+which would prevent filtering and matching operations from working properly. The
+inputs to the algorithm are an array of N-Quads (<var>nquads</var>), a JSON-LD
+filtering frame (<var>filterFrame</var>), a JSON-LD grouping frame
+(<var>groupFrame</var>). Additionally, any custom JSON-LD API options are
+expected to be given as an input. An object containing two properties is
+provided as output; <em>matching</em> and <em>nonmatching</em> each hold arrays
+of their associated N-Quads.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `skolemizedDocument` to the result of calling the algorithm in
+Section <a href="#toskolemizedjsonld"></a>, passing `nquads` and any custom
+JSON-LD API options (such as a document loader).
+            </li>
+            <li>
+Initialize `filteredDocument` to the result of calling the algorithm in Section
+<a href="#strictframe"></a>, passing `skolemizedDocument`, `filterFrame`, and
+any custom JSON-LD API options.
+            </li>
+            <li>
+Initialize `filteredNQuads` to the result of calling the algorithm in Section <a
+href="#todeskolemizedrdf"></a>, passing `filteredDocument` and any custom
+JSON-LD API options.
+            </li>
+            <li>
+Note: These next two steps can be performed in parallel.
+            </li>
+            <ol class="algorithm">
+              <li>
+Get the canonical blank node identifier map, `canonicalIdMap`, by calling
+[[RDF-CANON]], passing the joined `filteredNQuads`. Canonicalize `filteredNQuads
+Note: These two steps can be performed in parallel.
+              </li>
+              <li>
+Get the `groupResult` by calling the algorithm in Section
+<a href="#groupnquads"></a>, passing `filteredNQuads`, `filteredDocument`,
+`groupFrame`, and any custom JSON-LD API options.
+              </li>
+            </ol>
+            <li>
+Note: Next generate matching and non-matching maps composed of original indexes
+to original N-Quads. The `groupResult` is different; it contains matching and
+non-matching maps using the `filteredNQuads` indexes. Both maps of indexes are
+useful to callers.
+            </li>
+            <li>
+Initialize `matching` to a new map.
+            </li>
+            <li>
+Initialize `nonMatching` to a new map.
+            </li>
+            <li>
+Initialize filteredMatches to the values in `groupResult.matching`.
+            </li>
+            <li>
+Initialize filteredNonMatches to the values in `groupResult.nonMatching`.
+            </li>
+            <li>
+For each entry (`index`, `nq`) in `nquads`:
+              <ol class="algorithm">
+                <li>
+If `filteredMatches` includes `nq` then add the entry to `matching`.
+                </li>
+                <li>
+Otherwise, if `filteredNonMatching` includes `nq` then add the entry to
+`nonMatching`.
+                </li>
+              </ol>
+            </li>
+            <li>
+Initialize `labelMap` to the reverse of `canonicalIdMap`. `labelMap` uses
+canonical blank node identifiers as keys and original blank node identifiers as
+values.
+            </li>
+            <li>
+Return an object with "filtered" set to `groupResult`, "labelMap" set to
+`labelMap`, "matching" to `matching`, and "nonMatching" to `nonMatching`.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1591,6 +1591,45 @@ Return `paths`.
           </ol>
         </section>
 
+        <section>
+          <h4>jsonPointerToPaths</h4>
+
+          <p>
+The following algorithm converts a JSON Pointer [[RFC6901]] to an array of paths
+into a JSON tree. The required input is a JSON Pointer string
+(<var>pointer</var>). An array of paths (<em>paths</em>) is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `paths` to an empty array.
+            </li>
+            <li>
+Initialize `splitPath` to an array by splitting <var>pointer</var> on the
+"/" character and skipping the first, empty, split element. In Javascript
+notation, this step is equivalent to the following code:
+`pointer.split('/').slice(1)`
+            </li>
+            <li>
+For each `path` in `splitPath`:
+              <ol class="algorithm">
+                <li>
+If `path` does not include `~`, then add `path` to `paths`, converting it to
+an integer if it parses as one, leaving it as a string if it does not.
+                </li>
+                <li>
+Otherwise, unescape any JSON pointer escape sequences in `path` and add the
+result to `paths`.
+                </li>
+              </ol>
+            </li>
+            <li>
+Return `paths`.
+            </li>
+          </ol>
+        </section>
+
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1971,54 +1971,37 @@ section also include the verification of such a data integrity proof.
         </p>
 
         <section>
-          <h4>Add Proof (ecdsa-sd-2023)</h4>
+          <h4>Add Base Proof (ecdsa-sd-2023)</h4>
 
           <p>
-To generate a proof, the algorithm in
+To generate a base proof, the algorithm in
 <a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
 Section 4.1: Add Proof</a> in the Data Integrity
 [[VC-DATA-INTEGRITY]] specification MUST be executed.
 For that algorithm, the cryptographic suite specific
 <a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
 transformation algorithm</a> is defined in Section
-<a href="#transformation-ecdsa-sd-2023"></a>, the
+<a href="#base-proof-transformation-ecdsa-sd-2023"></a>, the
 <a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
-hashing algorithm</a> is defined in Section <a href="#hashing-ecdsa-sd-2023"></a>,
+hashing algorithm</a> is defined in Section <a href="#base-proof-hashing-ecdsa-sd-2023"></a>,
 and the
 <a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
 proof serialization algorithm</a> is defined in Section
-<a href="#proof-serialization-ecdsa-sd-2023"></a>.
+<a href="#base-proof-serialization-ecdsa-sd-2023"></a>.
           </p>
         </section>
 
         <section>
-          <h4>Verify Proof (ecdsa-sd-2023)</h4>
-
-          <p>
-To verify a proof, the algorithm in
-<a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
-Section 4.2: Verify Proof</a> in the Data Integrity
-[[VC-DATA-INTEGRITY]] specification MUST be executed.
-For that algorithm, the cryptographic suite specific
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
-transformation algorithm</a> is defined in Section
-<a href="#transformation-ecdsa-sd-2023"></a>, the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
-hashing algorithm</a> is defined in Section <a href="#hashing-ecdsa-sd-2023"></a>,
-and the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
-proof verification algorithm</a> is defined in Section
-<a href="#proof-verification-ecdsa-sd-2023"></a>.
-          </p>
-        </section>
-
-        <section>
-          <h4>Transformation (ecdsa-sd-2023)</h4>
+          <h4>Base Proof Transformation (ecdsa-sd-2023)</h4>
 
           <p>
 The following algorithm specifies how to transform an unsecured input document
 into a transformed document that is ready to be provided as input to the
-hashing algorithm in Section <a href="#hashing-ecdsa-sd-2023"></a>.
+hashing algorithm in Section <a href="#base-proof-hashing-ecdsa-sd-2023"></a>.
+Creates the data that will be used to generate a base proof. The inputs to the
+algorithm are the JSON-LD document to be signed, `document`, the proof options,
+`proof options`, an array of mandatory JSON pointers, `mandatoryPointers`, and
+any custom JSON-LD API options (such as a document loader).
           </p>
 
           <p>
@@ -2040,14 +2023,13 @@ encoding.
         </section>
 
         <section>
-          <h4>Hashing (ecdsa-sd-2023)</h4>
+          <h4>Base Proof Hashing (ecdsa-sd-2023)</h4>
 
           <p>
 The following algorithm specifies how to cryptographically hash a
 <em>transformed data document</em> and <em>proof configuration</em>
 into cryptographic hash data that is ready to be provided as input to the
-algorithms in Section <a href="#proof-serialization-ecdsa-sd-2023"></a> or
-Section <a href="#proof-verification-ecdsa-sd-2023"></a>.
+algorithms in Section <a href="#base-proof-serialization-ecdsa-sd-2023"></a>.
           </p>
 
           <p>
@@ -2064,12 +2046,13 @@ series of bytes is produced as output.
         </section>
 
         <section>
-          <h4>Proof Configuration (ecdsa-sd-2023)</h4>
+          <h4>Base Proof Configuration (ecdsa-sd-2023)</h4>
 
           <p>
 The following algorithm specifies how to generate a
 <em>proof configuration</em> from a set of <em>proof options</em>
-that is used as input to the <a href="#hashing-ecdsa-sd-2023">proof hashing algorithm</a>.
+that is used as input to the
+<a href="#base-proof-hashing-ecdsa-sd-2023">base proof hashing algorithm</a>.
           </p>
 
           <p>
@@ -2129,7 +2112,7 @@ Return <var>canonicalProofConfig</var>.
         </section>
 
         <section>
-          <h4>Proof Serialization (ecdsa-sd-2023)</h4>
+          <h4>Base Proof Serialization (ecdsa-sd-2023)</h4>
 
           <p>
 The following algorithm specifies how to serialize a digital signature from
@@ -2145,28 +2128,6 @@ cryptographic hash data (<var>hashData</var>) and
 cryptographic suite</a> (<var>type</var>) and MAY contain a cryptosuite
 identifier (<var>cryptosuite</var>). A single <em>digital proof</em> value
 represented as series of bytes is produced as output.
-          </p>
-
-          <ol class="algorithm">
-
-          </ol>
-
-        </section>
-
-        <section>
-          <h4>Proof Verification (ecdsa-sd-2023)</h4>
-
-          <p>
-The following algorithm specifies how to verify a digital signature from
-a set of cryptographic hash data. This
-algorithm is designed to be used in conjunction with the algorithms defined
-in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Algorithms</a>. Required inputs are
-cryptographic hash data (<var>hashData</var>),
-a digital signature (<var>proofBytes</var>) and
-proof options (<var>options</var>). A <em>verification result</em>
-represented as a boolean value is produced as output.
           </p>
 
           <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -1553,6 +1553,44 @@ Return <em>outputNquads</em>.
           </ol>
         </section>
 
+        <section>
+          <h4>jsonPointerToPaths</h4>
+
+          <p>
+The following algorithm converts a JSON Pointer [[RFC6901]] to an array of paths
+into a JSON tree. The required input is a JSON Pointer string
+(<var>pointer</var>). An array of paths (<em>paths</em>) is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `paths` to an empty array.
+            </li>
+            <li>
+Initialize `splitPath` to an array by splitting <var>pointer</var> on the
+"/" character and skipping the first, empty, split element. In Javascript
+notation, this step is equivalent to the following code:
+`pointer.split('/').slice(1)`
+            </li>
+            <li>
+For each `path` in `splitPath`:
+              <ol class="algorithm">
+                <li>
+If `path` does not include `~`, then add `path` to `paths`, converting it to
+an integer if it parses as one, leaving it as a string if it does not.
+                </li>
+                <li>
+Otherwise, unescape any JSON pointer escape sequences in `path` and add the
+result to `paths`.
+                </li>
+              </ol>
+            </li>
+            <li>
+Return `paths`.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1390,6 +1390,7 @@ schemes such as BBS.
           </p>
 
         </section>
+
         <section>
           <h4>labelMapCanonize</h4>
 
@@ -1409,7 +1410,41 @@ reverse of <var>labelMap</var>.
 Return <em>labelMapReplacementFunction</em>.
             </li>
           </ol>
+        </section>
 
+        <section>
+          <h4>skolemize</h4>
+
+          <p>
+The following algorithm replaces all blank node identifiers in an array of
+N-Quad statements with a URN. The required inputs are an array of N-Quad strings
+(<var>inputNquads</var>) and a URN scheme (<var>urnScheme</var>). An array of
+N-Quad strings, <em>skolemizedNquads</em>, is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Create a new array of N-Quad strings, <em>skolemizedNquads</em>.
+            </li>
+            <li>
+For each N-Quad string, <em>s1</em>, in the input array:
+            <ol class="algorithm">
+              <li>
+Create a new string, <em>s2</em>, that is a copy of <em>s1</em> replacing any
+occurrence of a blank node identifier with a URN ("urn:"), plus the input
+custom scheme (<var>urnScheme</var>), plus a colon (":"), and
+the value of the blank node identifier. For example, a regular expression
+of a similar form to the following would achieve the desired result:
+<code>s1.replace(/(_:([^\s]+))/g, '&lt;urn:custom-scheme:$2>')</code>.
+              </li>
+              <li>
+Append <em>s2</em> to <em>skolemizedNquads</em>.
+              </li>
+            </ol>
+            <li>
+Return <em>skolemizedNquads</em>.
+            </li>
+          </ol>
         </section>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -2560,17 +2560,18 @@ value, represented as an object, is produced as output.
             <li>
 Initialize `baseSignature`, `publicKey`, `signatures`, `labelMap`,
 `mandatoryIndexes`, `revealDocument` to the values associated with their
-property names in the object returned when calling "createDisclosureData",
-passing the `document`, `proof`, `selectivePointers`, and any custom JSON-LD API
-options, such as a document loader.
+property names in the object returned when calling the algorithm in
+Section <a href="#createdisclosuredata"></a>, passing the `document`, `proof`,
+`selectivePointers`, and any custom JSON-LD API options, such as a document
+loader.
             </li>
             <li>
 Initialize `newProof` to a shallow copy of `proof`.
             </li>
             <li>
-Replace `proofValue` in `newProof` with the result of calling
-"serializeDisclosureProofValue", passing `baseSignature`, `publicKey`,
-`signatures`, `labelMap`, and `mandatoryIndexes`.
+Replace `proofValue` in `newProof` with the result of calling the algorithm
+in Section <a href="#serializederivedproofvalue"></a>, passing
+`baseSignature`, `publicKey`, `signatures`, `labelMap`, and `mandatoryIndexes`.
             </li>
             <li>
 Set the value of the "proof" property in `revealDocument` to `newProof`.

--- a/index.html
+++ b/index.html
@@ -2015,33 +2015,21 @@ unsecured data document</a> (<var>unsecuredDocument</var>) and
 transformation options (<var>options</var>). The
 transformation options MUST contain a type identifier for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
-cryptographic suite</a> (<var>type</var>) and a cryptosuite
-identifier (<var>cryptosuite</var>). The
-transformation options MUST contain an array of mandatory JSON pointers
-(<var>mandatoryPointers</var>) and MAY contain additional options, such as a
-JSON-LD document loader. A <em>transformed data document</em> is
-produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
-encoding.
+cryptographic suite</a> (<var>type</var>), a cryptosuite
+identifier (<var>cryptosuite</var>), and a verification method
+(<var>verificationMethod</var>). The transformation options MUST contain an
+array of mandatory JSON pointers (<var>mandatoryPointers</var>) and MAY contain
+additional options, such as a JSON-LD document loader. A <em>transformed data
+document</em> is produced as output. Whenever this algorithm encodes strings, it
+MUST use UTF-8 encoding.
           </p>
 
           <ol class="algorithm">
             <li>
-Initialize `canonicalProofConfig` by calling the algorithm in Section
-<a href="#base-proof-configuration-ecdsa-sd-2023"></a> and passing
-<var>options</var> as the proof option parameters.
-            </li>
-            <li>
-Initialize `proofHash` to the result of calling the RDF Dataset Canonicalization
-algorithm [[RDF-CANON]] on `canonicalProofConfig` and then cryptographically
-hashing the result using the same hash that is used by the signature algorithm,
-i.e., SHA-256 for a P-256 curve. Note: This step can be performed in parallel;
-it only needs to be completed before this algorithm terminates as the result is
-part of the return value.
-            </li>
-            <li>
 Initialize `hmac` to an HMAC API using a locally generated and exportable HMAC
 key. The HMAC uses the same hash algorithm used in the signature algorithm,
-i.e., SHA-256 for a P-256 curve.
+which is detected via the <var>verificationMethod</var> provided to the
+function. i.e., SHA-256 for a P-256 curve.
             </li>
             <li>
 Initialize `nquads` to the result of calling the algorithm in Section
@@ -2070,16 +2058,12 @@ Initialize `mandatory` to the values in the `matching` map.
 Initialize `nonMandatory` to the values in the `nonMatching` map.
             </li>
             <li>
-Initialize `mandatoryHash` to the result of calling the the algorithm in Section
-<a href="#hashmandatorynquads"></a>, passing `mandatory`.
-            </li>
-            <li>
 Initialize `hmacKey` to the result of exporting the HMAC key from `hmac`.
             </li>
             <li>
-Return an object with "proofHash" set to `proofHash`, "mandatoryPointers" set to
-`mandatoryPointers`, "mandatoryHash" set to `mandatoryHash`, "nonMandatory" set
-to `nonMandatory`, and "hmacKey" set to `hmacKey`.
+Return an object with "mandatoryPointers" set to `mandatoryPointers`,
+"mandatory" set to `mandatory`, "nonMandatory" set to `nonMandatory`,
+and "hmacKey" set to `hmacKey`.
             </li>
           </ol>
         </section>
@@ -2097,12 +2081,32 @@ algorithms in Section <a href="#base-proof-serialization-ecdsa-sd-2023"></a>.
           <p>
 The required inputs to this algorithm are a <em>transformed data document</em>
 (<var>transformedDocument</var>) and <em>canonical proof configuration</em>
-(<var>canonicalProofConfig</var>). A single <em>hash data</em> value represented as
-series of bytes is produced as output.
+(<var>canonicalProofConfig</var>). A <em>hash data</em> value represented
+as an object is produced as output.
           </p>
 
           <ol class="algorithm">
-
+            <li>
+Initialize `proofHash` to the result of calling the RDF Dataset Canonicalization
+algorithm [[RDF-CANON]] on `canonicalProofConfig` and then cryptographically
+hashing the result using the same hash that is used by the signature algorithm,
+i.e., SHA-256 for a P-256 curve. Note: This step can be performed in parallel;
+it only needs to be completed before this algorithm terminates as the result is
+part of the return value.
+            </li>
+            <li>
+Initialize `mandatoryHash` to the result of calling the the algorithm in Section
+<a href="#hashmandatorynquads"></a>, passing
+<var>transformedDocument</var>.`mandatory`.
+            </li>
+            <li>
+Initialize `hashData` as a deep copy of <var>transformedDocument</var> and
+add `proofHash` as "proofHash" and `mandatoryHash` as "mandatoryHash" to that
+object.
+            </li>
+            <li>
+Return `hashData` as <em>hash data</em>.
+            </li>
           </ol>
 
         </section>

--- a/index.html
+++ b/index.html
@@ -1499,7 +1499,7 @@ Initialize `skolemizedQuads` to the result of calling <a href="#skolemize"></a>,
 with <var>inputNQuads</var> and "custom-scheme" as parameters. Implementations
 MAY choose a different <em>urnSchemeName</em> that is different than
 "custom-scheme" so long as the same scheme name is used in
-<a href="#toDeskolemizedRDF"></a> algorithm.
+<a href="#todeskolemizedrdf"></a> algorithm.
             </li>
             <li>
 Join `skolemizedQuads` into a single N-Quads string, `dataset`.
@@ -1512,6 +1512,42 @@ document loader), to convert `dataset` from RDF to a JSON-LD document.
             </li>
             <li>
 Return <em>skolemizedJSONLD</em>.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h4>toDeskolemizedRDF</h4>
+
+          <p>
+The following algorithm converts a skolemized JSON-LD document, such as one
+created using the Section <a href="#toskolemizedjsonld"></a> algorithm, to array of
+deskolemized N-Quads. The required inputs are a JSON-LD document,
+<em>skolemizedJSONLD</em>. An array of deskolemized N-Quad strings
+(<var>outputNquads</var>) is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `skolemizedDataset` to the result of calling the
+<a href="https://www.w3.org/TR/json-ld11-api/#deserialize-json-ld-to-rdf-algorithm">
+Deserialize JSON-LD to RDF</a> algorithm, passing any custom options (such as a
+document loader), to convert `skolemizedJSONLD` from JSON-LD to RDF in N-Quads
+format.
+            </li>
+            <li>
+Split `skolemizedDataset` into an array of individual N-Quads,
+`skolemizedNquads`.
+            </li>
+            <li>
+Set <var>outputNquads</var> to the result of calling the
+<a href="#deskolemize"></a> with `skolemizedNquads` and and "custom-scheme" as
+parameters. Implementations MAY choose a different <em>urnSchemeName</em> that
+is different than "custom-scheme" so long as the same scheme name is used in
+<a href="#toskolemizedjsonld"></a> algorithm.
+            </li>
+            <li>
+Return <em>outputNquads</em>.
             </li>
           </ol>
         </section>

--- a/index.html
+++ b/index.html
@@ -2210,6 +2210,45 @@ label map (<var>labelMap</var>). The output is a <em>compressed label map</em>.
 
         </section>
 
+        <section>
+          <h4>serializeDerivedProofValue</h4>
+
+          <p>
+The following algorithm serializes a derived proof value. The required inputs
+are a base signature (<var>baseSignature</var>), public key
+(<var>publicKey</var>), an array of signatures (<var>signatures</var>), a label
+map (<var>labelMap</var>), and an array of mandatory indexes
+(<var>mandatoryIndexes</var>). A single <em>derived proof</em> value, serialized
+as a byte string, is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `compressedLabelMap` to the result of calling the algorithm in
+Section <a href="#compresslabelmap"></a>, passing `labelMap` as the parameter.
+            </li>
+            <li>
+Initialize a byte array, `proofValue`, that starts with the ECDSA-SD disclosure
+proof header bytes `0xd9`, `0x5d`, and `0x01`.
+            </li>
+            <li>
+Initialize `components` to an array with five elements containing the values of:
+`baseSignature`, `publicKey`, `signatures`, `compressedLabelMap`, and
+`mandatoryIndexes`.
+            </li>
+            <li>
+CBOR-encode `components` and append it to `proofValue`.
+            </li>
+            <li>
+Return the <em>derived proof</em> as a string with the
+multibase-base64url-no-pad-encoding of `proofValue`. That is, return a string
+starting with "u" and ending with the base64url-no-pad-encoded value of
+`proofValue`.
+            </li>
+          </ol>
+
+        </section>
+
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -2191,20 +2191,20 @@ label map (<var>labelMap</var>). The output is a <em>compressed label map</em>.
 
           <ol class="algorithm">
             <li>
-              Initialize `map` to an empty map.
+Initialize `map` to an empty map.
               </li>
               <li>
-              For each entry (`k`, `v`) in `labelMap`:
+For each entry (`k`, `v`) in `labelMap`:
                 <ol class="algorithm">
                   <li>
-                Add an entry to `map` with a key that is a base-10 integer parsed from the
-                characters following the "c14n" prefix in `k` and a value that is a byte array
-                resulting from base64url-no-pad-decoding the characters after the "u" prefix in
+Add an entry to `map` with a key that is a base-10 integer parsed from the
+characters following the "c14n" prefix in `k` and a value that is a byte array
+resulting from base64url-no-pad-decoding the characters after the "u" prefix in
                 `v`.
                   </li>
                 </ol>
               <li>
-              Return `map` as <em>compressed label map</em>.
+Return `map` as <em>compressed label map</em>.
               </li>
           </ol>
 

--- a/index.html
+++ b/index.html
@@ -2153,6 +2153,27 @@ represented as series of bytes is produced as output.
 
         </section>
 
+        <section>
+          <h4>Proof Verification (ecdsa-sd-2023)</h4>
+
+          <p>
+The following algorithm specifies how to verify a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (<var>hashData</var>),
+a digital signature (<var>proofBytes</var>) and
+proof options (<var>options</var>). A <em>verification result</em>
+represented as a boolean value is produced as output.
+          </p>
+
+          <ol class="algorithm">
+
+          </ol>
+
+        </section>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -2181,6 +2181,35 @@ Return an object with properties matching `baseSignature`, `publicKey`,
 
         </section>
 
+        <section>
+          <h4>compressLabelMap</h4>
+
+          <p>
+The following algorithm compresses a label map. The required inputs are
+label map (<var>labelMap</var>). The output is a <em>compressed label map</em>.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+              Initialize `map` to an empty map.
+              </li>
+              <li>
+              For each entry (`k`, `v`) in `labelMap`:
+                <ol class="algorithm">
+                  <li>
+                Add an entry to `map` with a key that is a base-10 integer parsed from the
+                characters following the "c14n" prefix in `k` and a value that is a byte array
+                resulting from base64url-no-pad-decoding the characters after the "u" prefix in
+                `v`.
+                  </li>
+                </ol>
+              <li>
+              Return `map` as <em>compressed label map</em>.
+              </li>
+          </ol>
+
+        </section>
+
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -2025,6 +2025,45 @@ Return `baseProof` as <em>base proof</em>.
 
         </section>
 
+        <section>
+          <h4>parseBaseProofValue</h4>
+
+          <p>
+The following algorithm parses the components of an `ecdsa-sd-2023` selective
+disclosure base proof value. The required inputs are a proof value
+(<var>proofValue</var>). A single object <em>parsed base proof</em>, containing
+five elements, using the names "baseSignature", "publicKey", "hmacKey",
+"signatures", and "mandatoryPointers", is produced  as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Ensure the `proofValue` string starts with `u`, indicating that it is a
+multibase-base64url-no-pad-encoded value, throwing an error if it does not.
+            </li>
+            <li>
+Initialize `decodedProofValue` to the result of base64url-no-pad-decoding the
+substring after the leading `u` in `proofValue`.
+            </li>
+            <li>
+Ensure that the `decodedProofValue` starts with the ECDSA-SD base proof header
+bytes 0xd9, 0x5d, and 0x00, throwing an error if it does not.
+            </li>
+            <li>
+Initialize `components` to an array that is the result of CBOR-decoding the
+bytes that follow the three-byte ECDSA-SD base proof header. Ensure the result
+is an array of five elements.
+            </li>
+            <li>
+Return an object with properties set to the five elements, using the names
+"baseSignature", "publicKey", "hmacKey", "signatures", and "mandatoryPointers",
+respectively.
+            </li>
+          </ol>
+
+        </section>
+
+
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -1661,6 +1661,120 @@ Return <em>frame</em>.
           </ol>
         </section>
 
+        <section>
+          <h4>jsonPointersToFrame</h4>
+
+          <p>
+The following algorithm converts an array of JSON Pointers and a JSON-LD
+document to a JSON-LD Frame to be used on that specific document. The required
+input is an array of JSON Pointers (<var>pointers</var>) and a JSON-LD document
+(<var>document</var>). A JSON-LD frame (<em>frame</em>) is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If `pointers` is empty, return `null`.
+            </li>
+            <li>
+Initialize `frame` to an initial frame passing `document` as `value` to
+"createInitialFrame".
+            </li>
+            <li>
+For each `pointer` in `pointers` walk the document from root to the pointer
+target value building the frame:
+            </li>
+            <ol class="algorithm">
+              <li>
+Initialize `parentFrame` to `frame`.
+              </li>
+              <li>
+Initialize `parentValue` to `document`.
+              </li>
+              <li>
+Initialize `value` to `parentValue`.
+              </li>
+              <li>
+Initialize `valueFrame` to `parentFrame`.
+              </li>
+              <li>
+Parse the `pointer` into an array of `paths` using "pointerToPaths".
+              </li>
+              <li>
+For each `path` in `paths:
+              </li>
+              <ol class="algorithm">
+                <li>
+Set `parentFrame` to `valueFrame`.
+                </li>
+                <li>
+Set `parentValue` to `value`.
+                </li>
+                <li>
+Set `value` to `parentValue[path]`. If `value` is now undefined, throw an error
+indicating that the JSON pointer does not match the given `document`.
+                </li>
+                <li>
+Set `valueFrame` to `parentFrame[path]`.
+                </li>
+                <li>
+If `valueFrame` is undefined:
+                </li>
+                <ol class="algorithm">
+                  <li>
+If `value` is an array, set `valueFrame` to an empty array.
+                  </li>
+                  <li>
+Otherwise, set `valueFrame` to an initial frame passing `value` to
+"createInitialFrame".
+                  </li>
+                  <li>
+Set `parentFrame[path]` to `valueFrame`.
+                  </li>
+                </ol>
+              </ol>
+              <li>
+Note: Next we generate the final `valueFrame`.
+              </li>
+              <li>
+If `value` is not an object, then a literal has been selected: Set `valueFrame`
+to `value`.
+              </li>
+              <li>
+Otherwise, if `value` is an array: Set `valueFrame` to the result of mapping
+every element in `value` to a deep copy of itself. If any element in `value` is
+also an `array`, throw an error indicating that arrays of arrays are not
+supported.
+              </li>
+              <li>
+Otherwise: Set `valueFrame` to an object that merges a shallow copy of
+`valueFrame` with a deep copy of `value`, e.g., `{...valueFrame,
+&hellip;deepCopy(value)}`.
+              </li>
+              <li>
+If `paths` has a length of zero, then the whole `document` has been selected by
+the `pointer`: Set `frame` to `valueFrame`.
+              </li>
+              <li>
+Otherwise, a partial selection has been made by the pointer:
+                <ol class="algorithm">
+                  <li>
+Get the last `path`, `lastPath`, from `paths`.
+                  </li>
+                  <li>
+Set `parentFrame[lastPath]` to `valueFrame`.
+                  </li>
+                </ol>
+              <li>
+Set `frame['@context']` to a deep copy of `document['@context']`.
+              </li>
+              <li>
+Return `frame`.
+              </li>
+            </ol>
+          </ol>
+
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1495,11 +1495,12 @@ produced as output.
 
           <ol class="algorithm">
             <li>
-Initialize `skolemizedQuads` to the result of calling <a href="#skolemize"></a>,
-with <var>inputNQuads</var> and "custom-scheme" as parameters. Implementations
-MAY choose a different <em>urnSchemeName</em> that is different than
-"custom-scheme" so long as the same scheme name is used in
-<a href="#todeskolemizedrdf"></a> algorithm.
+Initialize `skolemizedQuads` to the result of calling the algorithm in
+Section <a href="#skolemize"></a>, with <var>inputNQuads</var> and
+"custom-scheme" as parameters. Implementations MAY choose a different
+<em>urnSchemeName</em> that is different than "custom-scheme" so long as the
+same scheme name is used in the algorithm in Section
+<a href="#todeskolemizedrdf"></a>.
             </li>
             <li>
 Join `skolemizedQuads` into a single N-Quads string, `dataset`.
@@ -1521,8 +1522,8 @@ Return <em>skolemizedJSONLD</em>.
 
           <p>
 The following algorithm converts a skolemized JSON-LD document, such as one
-created using the Section <a href="#toskolemizedjsonld"></a> algorithm, to array of
-deskolemized N-Quads. The required inputs are a JSON-LD document,
+created using the algorithm in Section <a href="#toskolemizedjsonld"></a>, to an
+array of deskolemized N-Quads. The required inputs are a JSON-LD document,
 <em>skolemizedJSONLD</em>. An array of deskolemized N-Quad strings
 (<var>outputNquads</var>) is produced as output.
           </p>
@@ -1540,11 +1541,11 @@ Split `skolemizedDataset` into an array of individual N-Quads,
 `skolemizedNquads`.
             </li>
             <li>
-Set <var>outputNquads</var> to the result of calling the
-<a href="#deskolemize"></a> with `skolemizedNquads` and and "custom-scheme" as
+Set <var>outputNquads</var> to the result of calling the algorithm in Section
+<a href="#deskolemize"></a> with `skolemizedNquads` and "custom-scheme" as
 parameters. Implementations MAY choose a different <em>urnSchemeName</em> that
 is different than "custom-scheme" so long as the same scheme name is used in
-<a href="#toskolemizedjsonld"></a> algorithm.
+the algorithm in Section <a href="#toskolemizedjsonld"></a>.
             </li>
             <li>
 Return <em>outputNquads</em>.

--- a/index.html
+++ b/index.html
@@ -1020,6 +1020,333 @@ Return <var>verificationResult</var> as the <em>verification result</em>.
 
         </section>
       </section>
+      <section>
+        <h3>jcs-ecdsa-2019</h3>
+
+        <p>
+The `jcs-ecdsa-2019` cryptographic suite takes an input document, canonicalizes
+the document using the JSON Canonicalization Scheme [[RFC8785]], and then
+cryptographically hashes and signs the output
+resulting in the production of a data integrity proof. The algorithms in this
+section also include the verification of such a data integrity proof.
+        </p>
+
+        <section>
+          <h4>Add Proof (jcs-ecdsa-2019)</h4>
+
+          <p>
+To generate a proof, the algorithm in
+<a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
+Section 4.1: Add Proof</a> of the Data Integrity
+[[VC-DATA-INTEGRITY]] specification MUST be executed.
+For that algorithm, the cryptographic suite-specific
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
+transformation algorithm</a> is defined in Section
+<a href="#transformation-jcs-ecdsa-2019"></a>, the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
+hashing algorithm</a> is defined in Section <a href="#hashing-jcs-ecdsa-2019"></a>,
+and the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
+proof serialization algorithm</a> is defined in Section
+<a href="#proof-serialization-jcs-ecdsa-2019"></a>.
+          </p>
+        </section>
+
+        <section>
+          <h4>Verify Proof (jcs-ecdsa-2019)</h4>
+
+          <p>
+To verify a proof, the algorithm in
+<a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
+Section 4.2: Verify Proof</a> of the Data Integrity
+[[VC-DATA-INTEGRITY]] specification MUST be executed.
+For that algorithm, the cryptographic suite-specific
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
+transformation algorithm</a> is defined in Section
+<a href="#transformation-jcs-ecdsa-2019"></a>, the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
+hashing algorithm</a> is defined in Section <a href="#hashing-jcs-ecdsa-2019"></a>,
+and the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
+proof verification algorithm</a> is defined in Section
+<a href="#proof-verification-jcs-ecdsa-2019"></a>.
+          </p>
+        </section>
+
+        <section>
+          <h4>Transformation (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to transform an unsecured input document
+into a transformed document that is ready to be provided as input to the
+hashing algorithm in Section <a href="#hashing-jcs-ecdsa-2019"></a>.
+          </p>
+
+          <p>
+Required inputs to this algorithm are an
+<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
+unsecured data document</a> (<var>unsecuredDocument</var>) and
+transformation options (<var>options</var>). The
+transformation options MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and a cryptosuite
+identifier (<var>cryptosuite</var>). A <em>transformed data document</em> is
+produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
+encoding.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If <var>options</var>.<var>type</var> is not set to the string
+`DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
+set to the string `jcs-ecdsa-2019`, then a `PROOF_TRANSFORMATION_ERROR` MUST be
+raised.
+            </li>
+            <li>
+Let <var>canonicalDocument</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>unsecuredDocument</var>.
+            </li>
+            <li>
+Set <var>output</var> to the value of <var>canonicalDocument</var>.
+            </li>
+            <li>
+Return <var>canonicalDocument</var> as the <em>transformed data document</em>.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h4>Hashing (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to cryptographically hash a
+<em>transformed data document</em> and <em>proof configuration</em>
+into cryptographic hash data that is ready to be provided as input to the
+algorithms in Section <a href="#proof-serialization-jcs-ecdsa-2019"></a> or
+Section <a href="#proof-verification-jcs-ecdsa-2019"></a>. One must use the
+hash algorithm appropriate in security level to the curve used, i.e., for curve
+P-256 one uses SHA-256, and for curve P-384 one uses SHA-384.
+          </p>
+
+          <p>
+The required inputs to this algorithm are a <em>transformed data document</em>
+(<var>transformedDocument</var>) and a <em>canonical proof configuration</em>
+(<var>canonicalProofConfig</var>). A single <em>hash data</em> value represented as
+series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>transformedDocumentHash</var> be the result of applying the SHA-256
+(SHA-2 with 256-bit output) or SHA-384 (SHA-2 with 384-bit output)
+cryptographic hashing algorithm [[RFC6234]] to the
+respective curve P-256 or curve P-384 <var>transformedDocument</var>.
+Respective <var>transformedDocumentHash</var> will be exactly 32 or 48 bytes
+in size.
+            </li>
+            <li>
+Let <var>proofConfigHash</var> be the result of applying the SHA-256
+(SHA-2 with 256-bit output) or SHA-384 (SHA-2 with 384-bit output)
+cryptographic hashing algorithm [[RFC6234]] to the
+respective curve P-256 or curve P-384 <var>canonicalProofConfig</var>.
+Respective <var>proofConfigHash</var> will be exactly 32 or 48 bytes in size.
+            </li>
+            <li>
+Let <var>hashData</var> be the result of concatenating <var>proofConfigHash</var> (the
+first hash) followed by <var>transformedDocumentHash</var> (the second hash).
+            </li>
+            <li>
+Return <var>hashData</var> as the <em>hash data</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Configuration (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to generate a
+<em>proof configuration</em> from a set of <em>proof options</em>
+that is used as input to the <a href="#hashing-jcs-ecdsa-2019">proof hashing algorithm</a>.
+          </p>
+
+          <p>
+The required inputs to this algorithm are <em>proof options</em>
+(<var>options</var>). The <em>proof options</em> MUST contain a type identifier
+for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and MUST contain a cryptosuite
+identifier (<var>cryptosuite</var>). A <em>proof configuration</em>
+object is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>proofConfig</var> be an empty object.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>type</var> to
+<var>options</var>.<var>type</var>.
+            </li>
+            <li>
+If <var>options</var>.<var>cryptosuite</var> is set, set
+<var>proofConfig</var>.<var>cryptosuite</var> to its value.
+            </li>
+            <li>
+If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
+<var>proofConfig</var>.<var>cryptosuite</var> is not set to `jcs-ecdsa-2019`, an
+`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>created</var> to
+<var>options</var>.<var>created</var>. If the value is not a valid
+[[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>verificationMethod</var> to
+<var>options</var>.<var>verificationMethod</var>.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>proofPurpose</var> to
+<var>options</var>.<var>proofPurpose</var>.
+            </li>
+            <li>
+Let <var>canonicalProofConfig</var> be the result of applying the
+JSON Canonicalization Scheme [[RFC8785]] to the <var>proofConfig</var>.
+            </li>
+            <li>
+Return <var>canonicalProofConfig</var>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Serialization (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to serialize a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (<var>hashData</var>) and
+<em>proof options</em> (<var>options</var>). The
+<em>proof options</em> MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and MAY contain a cryptosuite
+identifier (<var>cryptosuite</var>). A single <em>digital proof</em> value
+represented as series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>privateKeyBytes</var> be the result of retrieving the
+private key bytes associated with the
+<var>options</var>.<var>verificationMethod</var> value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Retrieving Cryptographic Material</a>.
+            </li>
+            <li>
+Let <var>proofBytes</var> be the result of applying the Elliptic Curve Digital
+Signature Algorithm (ECDSA) [[FIPS-186-5]], with <var>hashData</var> as the data
+to be signed using the private key specified by <var>privateKeyBytes</var>.
+<var>proofBytes</var> will be exactly 64 bytes in size for a P-256 key, and
+96 bytes in size for a P-384 key.
+            </li>
+            <li>
+Return <var>proofBytes</var> as the <em>digital proof</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>Proof Verification (jcs-ecdsa-2019)</h4>
+
+          <p>
+The following algorithm specifies how to verify a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (<var>hashData</var>),
+a digital signature (<var>proofBytes</var>), and
+proof options (<var>options</var>). A <em>verification result</em>
+represented as a boolean value is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Let <var>publicKeyBytes</var> be the result of retrieving the
+public key bytes associated with the
+<var>options</var>.<var>verificationMethod</var> value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Retrieving Cryptographic Material</a>.
+            </li>
+            <li>
+Let <var>verificationResult</var> be the result of applying the verification
+algorithm, Elliptic Curve Digital Signature Algorithm (ECDSA) [[FIPS-186-5]],
+with <var>hashData</var> as the data to be verified against the
+<var>proofBytes</var> using the public key specified by
+<var>publicKeyBytes</var>.
+            </li>
+            <li>
+Return <var>verificationResult</var> as the <em>verification result</em>.
+            </li>
+          </ol>
+
+        </section>
+      </section>
+
+      <section>
+        <h4>Selective Disclosure Primitives</h4>
+
+        <p>
+The following section contains a set of functions that are used throughout
+cryptographic suites that perform selective disclosure.
+        </p>
+
+        <section>
+          <h4>labelReplacementCanonize</h4>
+
+          <p>
+The following algorithm canonizes a JSON-LD document and replaces any blank node
+identifiers in the canonicalized document by applying a label replacement
+function, <var>labelReplacementFunction</var>. The required inputs are a JSON-LD
+document (<var>document</var>) and a label replacement functon
+(</var>labelReplacementFunction<var>). A N-Quads representation of the
+<em>canonized result</em>, with the replaced blank node labels, and a map from
+the old blank node IDs to the new blank node IDs, <em>map</em> is produced as
+output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Run the RDF Dataset Canonicalization Algorithm [[RDFC-1.0]] on
+<var>document</var>, passing any custom options (such as a document loader), and
+get the canonicalized dataset as output, which includes a canonical bnode
+identifier map, <var>canonicalIdMap</var>.
+            </li>
+            <li>
+Pass <var>canonicalIdMap</var> to <var>labelReplacementFunction</var> to produce
+a new bnode identifier map, <em>bnodeIdMap</em>.
+            </li>
+            <li>
+Produce canonical N-Quads representation, <em>canonized result</em>, using
+canonicalized dataset along with <em>bnodeIdMap</em> and return it.
+            </li>
+          </ol>
+
+        </section>
+
+      </section>
+
     </section>
     <section class="informative">
       <h2>Security Considerations</h2>

--- a/index.html
+++ b/index.html
@@ -1962,6 +1962,14 @@ Return `mandatoryHash`.
       <section>
         <h3>ecdsa-sd-2023</h3>
 
+        <p class="issue" title="(AT RISK) Pending implementation feedback and security reviews.">
+The Working Group is seeking implementer feedback on this cryptographic suite
+as well as horizonal security review on the feature from parties at W3C and
+IETF. Those reviews might result in significant changes to this algorithm, or
+the removal of the algorithm from the specification during the Candidate
+Recommendation phase.
+        </p>
+
         <p>
 The `ecdsa-sd-2023` cryptographic suite takes an input document, canonicalizes
 the document using the Universal RDF Dataset Canonicalization Algorithm

--- a/index.html
+++ b/index.html
@@ -2199,6 +2199,42 @@ Return the concatenation of <var>proofHash</var>, <var>publicKey</var>, and
         </section>
 
         <section>
+          <h4>serializeBaseProofValue</h4>
+
+          <p>
+The following algorithm serializes the base proof value, including the
+base signature, public key, HMAC key, signatures, and mandatory pointers.
+The required inputs are a base signature <var>baseSignature</var>, a public key
+<var>publicKey</var>, an HMAC key <var>hmacKey</var>, an array of
+<var>signatures</var>, and an array of <var>mandatoryPointers</var>.
+A single <em>base proof</em> string value is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize a byte array, `proofValue`, that starts with the ECDSA-SD base proof
+header bytes 0xd9, 0x5d, and 0x00.
+            </li>
+            <li>
+Initialize `components` to an array with five elements containing the values of:
+`baseSignature`, `publicKey`, `hmacKey`, `signatures`, and `mandatoryPointers`.
+            </li>
+            <li>
+CBOR-encode `components` and append it to `proofValue`.
+            </li>
+            <li>
+Initialize `baseProof` to a string with the multibase-base64url-no-pad-encoding
+of `proofValue`. That is, return a string starting with "u" and ending with the
+base64url-no-pad-encoded value of `proofValue`.
+            </li>
+            <li>
+Return `baseProof` as <em>base proof</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
           <h4>Base Proof Serialization (ecdsa-sd-2023)</h4>
 
           <p>

--- a/index.html
+++ b/index.html
@@ -1991,6 +1991,27 @@ proof serialization algorithm</a> is defined in Section
           </p>
         </section>
 
+        <section>
+          <h4>Verify Proof (ecdsa-sd-2023)</h4>
+
+          <p>
+To verify a proof, the algorithm in
+<a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
+Section 4.2: Verify Proof</a> in the Data Integrity
+[[VC-DATA-INTEGRITY]] specification MUST be executed.
+For that algorithm, the cryptographic suite specific
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
+transformation algorithm</a> is defined in Section
+<a href="#transformation-ecdsa-sd-2023"></a>, the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
+hashing algorithm</a> is defined in Section <a href="#hashing-ecdsa-sd-2023"></a>,
+and the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
+proof verification algorithm</a> is defined in Section
+<a href="#proof-verification-ecdsa-sd-2023"></a>.
+          </p>
+        </section>
+
         </section>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -2178,6 +2178,27 @@ Return <var>canonicalProofConfig</var>.
         </section>
 
         <section>
+          <h4>serializeSignData</h4>
+
+          <p>
+The following algorithm serializes the data that is to be signed by the private
+key associated with the base proof verification method. The required inputs are
+the proof options hash (<var>proofHash</var>), the proof-scoped multikey-encoded
+public key (<var>publicKey</var>), and the mandatory hash
+(<var>mandatoryHash</var>). A single <em>sign data</em> value,
+represented as series of bytes, is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Return the concatenation of <var>proofHash</var>, <var>publicKey</var>, and
+<var>mandatoryHash</var>, in that order, as <em>sign data</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
           <h4>Base Proof Serialization (ecdsa-sd-2023)</h4>
 
           <p>

--- a/index.html
+++ b/index.html
@@ -1924,6 +1924,31 @@ Return an object with "filtered" set to `groupResult`, "labelMap" set to
           </ol>
         </section>
 
+        <section>
+          <h4>hashMandatoryNQuads</h4>
+
+          <p>
+The following algorithm cryptographically hashes an array of mandatory to
+disclose N-Quads using a provided hashing API. The required input is an array of
+mandatory to disclose N-Quads (<var>mandatory</var>) and a hashing function
+(<var>hasher</var>). A cryptographic hash (<em>mandatoryHash</em>) is produced
+as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `bytes` to the UTF-8 representation of the joined `mandatory`
+N-Quads.
+            </li>
+            <li>
+Initialize `mandatoryHash` to the result of using `hasher` to hash `bytes`.
+            </li>
+            <li>
+Return `mandatoryHash`.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1592,44 +1592,6 @@ Return `paths`.
         </section>
 
         <section>
-          <h4>jsonPointerToPaths</h4>
-
-          <p>
-The following algorithm converts a JSON Pointer [[RFC6901]] to an array of paths
-into a JSON tree. The required input is a JSON Pointer string
-(<var>pointer</var>). An array of paths (<em>paths</em>) is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Initialize `paths` to an empty array.
-            </li>
-            <li>
-Initialize `splitPath` to an array by splitting <var>pointer</var> on the
-"/" character and skipping the first, empty, split element. In Javascript
-notation, this step is equivalent to the following code:
-`pointer.split('/').slice(1)`
-            </li>
-            <li>
-For each `path` in `splitPath`:
-              <ol class="algorithm">
-                <li>
-If `path` does not include `~`, then add `path` to `paths`, converting it to
-an integer if it parses as one, leaving it as a string if it does not.
-                </li>
-                <li>
-Otherwise, unescape any JSON pointer escape sequences in `path` and add the
-result to `paths`.
-                </li>
-              </ol>
-            </li>
-            <li>
-Return `paths`.
-            </li>
-          </ol>
-        </section>
-
-        <section>
           <h4>createInitialFrame</h4>
 
           <p>

--- a/index.html
+++ b/index.html
@@ -2128,6 +2128,32 @@ Return <var>canonicalProofConfig</var>.
 
         </section>
 
+        <section>
+          <h4>Proof Serialization (ecdsa-sd-2023)</h4>
+
+          <p>
+The following algorithm specifies how to serialize a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a data-cite="vc-data-integrity#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (<var>hashData</var>) and
+<em>proof options</em> (<var>options</var>). The
+<em>proof options</em> MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and MAY contain a cryptosuite
+identifier (<var>cryptosuite</var>). A single <em>digital proof</em> value
+represented as series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+
+          </ol>
+
+        </section>
+
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1963,6 +1963,14 @@ Return `mandatoryHash`.
       <section>
         <h3>ecdsa-sd-2023 Functions</h3>
 
+        <p class="issue" title="(AT RISK) Pending implementation feedback and security reviews.">
+The Working Group is seeking implementer feedback on these cryptographic suite
+functions as well as horizonal security review on the feature from parties at
+W3C and IETF. Those reviews might result in significant changes to these
+algorithms, or the removal of the algorithms from the specification during the
+Candidate Recommendation phase.
+        </p>
+
         <p>
 This section contains subalgorithms that are useful to the `ecdsa-sd-2023`
 cryptographic suite.

--- a/index.html
+++ b/index.html
@@ -1320,10 +1320,10 @@ The following algorithm canonizes a JSON-LD document and replaces any blank node
 identifiers in the canonicalized document by applying a label replacement
 function, <var>labelReplacementFunction</var>. The required inputs are a JSON-LD
 document (<var>document</var>) and a label replacement functon
-(</var>labelReplacementFunction<var>). A N-Quads representation of the
+(<var>labelReplacementFunction</var>). A N-Quads representation of the
 <em>canonized result</em>, with the replaced blank node labels, and a map from
-the old blank node IDs to the new blank node IDs, <em>map</em> is produced as
-output.
+the old blank node IDs to the new blank node IDs, <em>bnodeIdMap</em>, is
+produced as output.
           </p>
 
           <ol class="algorithm">
@@ -1342,6 +1342,52 @@ Produce canonical N-Quads representation, <em>canonized result</em>, using
 canonicalized dataset along with <em>bnodeIdMap</em> and return it.
             </li>
           </ol>
+
+        </section>
+
+        <section>
+          <h4>hmacIdCanonize</h4>
+
+          <p>
+The following algorithm creates a label replacement function that uses an
+HMAC to replace canonical blank node identifiers with their encoded HMAC
+digests. The required inputs are a canonical node identifier map,
+<var>canonicalIdMap</var>. A blank node identifier map, <em>bnodeIdMap</em>, is
+produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Generate a new empty bnode identifier map, <em>bnodeIdMap</em>.
+            </li>
+            <li>
+For each map entry in <var>canonicalIdMap</var>:
+              <ol class="algorithm">
+                <li>
+HMAC the canonical identifier from the entry to get an HMAC digest,
+<em>digest</em>.
+                </li>
+                <li>
+Generate a new string value, <em>b64urlDigest</em>, and initialize it to "u"
+followed by appending a base64url-no-pad encoded version of the <em>digest</em>
+value.
+                </li>
+                <li>
+Add this new entry to <em>bnodeIdMap</em>.
+                </li>
+              </ol>
+            </li>
+            <li>
+Return <em>bnodeIdMap</em>.
+            </li>
+          </ol>
+
+          <p class="note" title="Other algorithms are possible">
+A different primitive could be created that sorted the resulting HMAC digests
+and assigned labels using a prefix and integers based on their sorted order
+instead. This primitive might be useful for index-based selective disclosure
+schemes such as BBS.
+          </p>
 
         </section>
 

--- a/index.html
+++ b/index.html
@@ -1957,6 +1957,41 @@ Return `mandatoryHash`.
             </li>
           </ol>
         </section>
+      </section>
+
+      <section>
+        <h3>ecdsa-sd-2023</h3>
+
+        <p>
+The `ecdsa-sd-2023` cryptographic suite takes an input document, canonicalizes
+the document using the Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]], and then cryptographically hashes and signs the output
+resulting in the production of a data integrity proof. The algorithms in this
+section also include the verification of such a data integrity proof.
+        </p>
+
+        <section>
+          <h4>Add Proof (ecdsa-sd-2023)</h4>
+
+          <p>
+To generate a proof, the algorithm in
+<a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
+Section 4.1: Add Proof</a> in the Data Integrity
+[[VC-DATA-INTEGRITY]] specification MUST be executed.
+For that algorithm, the cryptographic suite specific
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
+transformation algorithm</a> is defined in Section
+<a href="#transformation-ecdsa-sd-2023"></a>, the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
+hashing algorithm</a> is defined in Section <a href="#hashing-ecdsa-sd-2023"></a>,
+and the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
+proof serialization algorithm</a> is defined in Section
+<a href="#proof-serialization-ecdsa-sd-2023"></a>.
+          </p>
+        </section>
+
+        </section>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1629,6 +1629,37 @@ Return `paths`.
           </ol>
         </section>
 
+        <section>
+          <h4>createInitialFrame</h4>
+
+          <p>
+The following algorithm creates an initial JSON-LD frame based on a JSON-LD
+object. This is a helper function used within the algorithm in
+Section <a href="#jsonpointerstoframe"></a>. The required input is a
+JSON-LD object (<var>value</var>). A JSON-LD frame <em>frame</em> is produced
+as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize <em>frame</em> to an empty object.
+            </li>
+            <li>
+If <var>value</var> has an `id` that is not a blank node identifier, set
+`frame.id` to its value. Note: All non-blank node identifiers in the path of
+any JSON Pointer MUST be included in the frame, this includes any root document
+identifier.
+            </li>
+            <li>
+If <var>value</var>.`type` is set, set <em>frame</em>.`type` to its value.
+Note: All `type`s in the path of any JSON Pointer MUST be included in the frame,
+this includes any root document `type`.
+            </li>
+            <li>
+Return <em>frame</em>.
+            </li>
+          </ol>
+        </section>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -2006,10 +2006,6 @@ proof serialization algorithm</a> is defined in Section
 The following algorithm specifies how to transform an unsecured input document
 into a transformed document that is ready to be provided as input to the
 hashing algorithm in Section <a href="#base-proof-hashing-ecdsa-sd-2023"></a>.
-Creates the data that will be used to generate a base proof. The inputs to the
-algorithm are the JSON-LD document to be signed, `document`, the proof options,
-`proof options`, an array of mandatory JSON pointers, `mandatoryPointers`, and
-any custom JSON-LD API options (such as a document loader).
           </p>
 
           <p>
@@ -2020,13 +2016,71 @@ transformation options (<var>options</var>). The
 transformation options MUST contain a type identifier for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
 cryptographic suite</a> (<var>type</var>) and a cryptosuite
-identifier (<var>cryptosuite</var>). A <em>transformed data document</em> is
+identifier (<var>cryptosuite</var>). The
+transformation options MUST contain an array of mandatory JSON pointers
+(<var>mandatoryPointers</var>) and MAY contain additional options, such as a
+JSON-LD document loader. A <em>transformed data document</em> is
 produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
 encoding.
           </p>
 
           <ol class="algorithm">
-
+            <li>
+Initialize `canonicalProofConfig` by calling the algorithm in Section
+<a href="#base-proof-configuration-ecdsa-sd-2023"></a> and passing
+<var>options</var> as the proof option parameters.
+            </li>
+            <li>
+Initialize `proofHash` to the result of calling the RDF Dataset Canonicalization
+algorithm [[RDF-CANON]] on `canonicalProofConfig` and then cryptographically
+hashing the result using the same hash that is used by the signature algorithm,
+i.e., SHA-256 for a P-256 curve. Note: This step can be performed in parallel;
+it only needs to be completed before this algorithm terminates as the result is
+part of the return value.
+            </li>
+            <li>
+Initialize `hmac` to an HMAC API using a locally generated and exportable HMAC
+key. The HMAC uses the same hash algorithm used in the signature algorithm,
+i.e., SHA-256 for a P-256 curve.
+            </li>
+            <li>
+Initialize `nquads` to the result of calling the algorithm in Section
+<a href="#labelreplacementcanonize"></a>, passing `unsecuredDocument`, the
+result of calling the algorithm in Section
+<a href="#labelmapcanonize"></a> (passing `hmac`) as the
+`labelReplacementFunction`, and any custom JSON-LD API options. Note: This step
+transforms the document into an array of canonical N-Quads with pseudorandom
+blank node identifiers based on `hmac`.
+            </li>
+            <li>
+Initialize `mandatoryFrame` to the result of calling the algorithm in Section
+<a href="#jsonpointerstoframe"></a>, passing `document` and `mandatoryPointers` as
+`pointers`.
+            </li>
+            <li>
+Initialize `matching` and `nonMatching` to the result of calling the algorithm
+in Section <a href="#groupnquads"></a>, passing `nquads`, `mandatoryFrame` as
+`frame`, and any custom JSON-LD API options. Note: This step separates the
+N-Quads to mandatory (to disclose) and non-mandatory groups.
+            </li>
+            <li>
+Initialize `mandatory` to the values in the `matching` map.
+            </li>
+            <li>
+Initialize `nonMandatory` to the values in the `nonMatching` map.
+            </li>
+            <li>
+Initialize `mandatoryHash` to the result of calling the the algorithm in Section
+<a href="#hashmandatorynquads"></a>, passing `mandatory`.
+            </li>
+            <li>
+Initialize `hmacKey` to the result of exporting the HMAC key from `hmac`.
+            </li>
+            <li>
+Return an object with "proofHash" set to `proofHash`, "mandatoryPointers" set to
+`mandatoryPointers`, "mandatoryHash" set to `mandatoryHash`, "nonMandatory" set
+to `nonMandatory`, and "hmacKey" set to `hmacKey`.
+            </li>
           </ol>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@ match the verification relationship expressed by the verification method
           <p>
 The `proofValue` property of the proof MUST be an ECDSA or deterministic ECDSA
 signature produced according to [[FIPS-186-5]] using the curves and hashes as
-specified in section <a href="#algorithms"></a>, encoded according to section 7 
+specified in section <a href="#algorithms"></a>, encoded according to section 7
 of [[RFC4754]] (sometimes referred to as the IEEE P1363 format), and serialized
 according to [[MULTIBASE]] using the base58-btc base encoding.
           </p>

--- a/index.html
+++ b/index.html
@@ -1775,6 +1775,30 @@ Return `frame`.
           </ol>
         </section>
 
+        <section>
+          <h4>strictFrame</h4>
+
+          <p>
+The following algorithm performs a JSON-LD framing operation on a JSON-LD
+document with strict framing options. The required inputs are a JSON-LD Document
+(<var>document</var>) and a JSON-LD Frame (<var>frame</var>). A JSON-LD document
+(<em>framedDocument</em>) is generated as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Set <em>framedDocument</em> to the result of the
+<a href="https://www.w3.org/TR/json-ld11-framing/#framing">
+JSON-LD Framing algorithm</a>, passing `document` and `frame`, and setting the
+options `requireAll`, `explicit`, and `omitGraph` to `true`. Any additional
+custom options passed, such as a document loader, is included as well.
+            </li>
+            <li>
+Return <em>framedDocument</em>.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1390,6 +1390,27 @@ schemes such as BBS.
           </p>
 
         </section>
+        <section>
+          <h4>labelMapCanonize</h4>
+
+          <p>
+The following algorithm creates a label replacement function that uses a label
+map to replace canonical blank node identifiers with the associated value from
+the labeel map. The required inputs are a label map, <var>labelMap</var>. A
+function, <em>labelMapReplacementFunction</em>, is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Set <em>labelMapReplacementFunction</em> to a function that returns the
+reverse of <var>labelMap</var>.
+            </li>
+            <li>
+Return <em>labelMapReplacementFunction</em>.
+            </li>
+          </ol>
+
+        </section>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1447,6 +1447,43 @@ Return <em>skolemizedNquads</em>.
           </ol>
         </section>
 
+
+        <section>
+          <h4>deskolemize</h4>
+
+          <p>
+The following algorithm replaces all custom scheme URNs in an array of
+N-Quad statements with a blank node identifier. The required inputs are an array of N-Quad strings
+(<var>inputNquads</var>) and a URN scheme (<var>urnScheme</var>). An array of
+N-Quad strings, <em>deskolemizedNquads</em>, is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Create a new array of N-Quad strings, <em>deskolemizedNquads</em>.
+            </li>
+            <li>
+For each N-Quad string, <em>s1</em>, in the <var>inputNquads</var> array:
+            <ol class="algorithm">
+              <li>
+Create a new string, <em>s2</em>, that is a copy of <em>s1</em> replacing any
+occurrence of a URN ("urn:"), plus the input
+custom scheme (<var>urnScheme</var>), plus a colon (":"), and
+the value of the blank node identifier with a blank node prefix ("_:"), plus
+the value of the blank node identifier. For example, a regular expression
+of a similar form to the following would achieve the desired result:
+<code>s1.replace(/(&lt;urn:custom-scheme:([^>]+)>)/g, '_:$2').</code>.
+              </li>
+              <li>
+Append <em>s2</em> to <em>deskolemizedNquads</em>.
+              </li>
+            </ol>
+            <li>
+Return <em>deskolemizedNquads</em>.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -2320,6 +2320,48 @@ Return `proofValue` as <em>digital proof</em>.
 
         <section>
           <h4>Add Derived Proof (ecdsa-sd-2023)</h4>
+
+          <p>
+The following algorithm creates a selective disclosure derived proof; called by
+a <a>holder</a> of an `ecdsa-sd-2023`-protected <a>verifiable credential</a>.
+The derived proof is to be given to the <a>verifier</a>. The inputs include a
+JSON-LD document (<var>document</var>), an ECDSA-SD base proof
+(<var>proof</var>), an array of JSON pointers to use to selectively disclose
+statements (<var>selectivePointers</var>), and any custom JSON-LD API options,
+such as a document loader. A single <em>selectively revealed document</em>
+value, represented as an object, is produced as output.
+          </p>
+
+          <ol>
+            <li>
+Initialize `baseSignature`, `publicKey`, `signatures`, `labelMap`,
+`mandatoryIndexes`, `revealDocument` to the values associated with their
+property names in the object returned when calling "createDisclosureData",
+passing the `document`, `proof`, `selectivePointers`, and any custom JSON-LD API
+options, such as a document loader.
+            </li>
+            <li>
+Initialize `newProof` to a shallow copy of `proof`.
+            </li>
+            <li>
+Replace `proofValue` in `newProof` with the result of calling
+"serializeDisclosureProofValue", passing `baseSignature`, `publicKey`,
+`signatures`, `labelMap`, and `mandatoryIndexes`.
+            </li>
+            <li>
+Set the value of the "proof" property in `revealDocument` to `newProof`.
+            </li>
+            <li>
+If `revealDocument` has an `@context` field that includes a <a>verifiable
+credential</a> base context and it has a "credentialSubject" property that is a
+string, set the "credentialSubject" value to an object with an "id" value that
+matches the original string value.
+            </li>
+            <li>
+Return `revealDocument` as the <em>selectively revealed document</em>.
+            </li>
+          </ol>
+
         </section>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -2012,7 +2012,33 @@ proof verification algorithm</a> is defined in Section
           </p>
         </section>
 
+        <section>
+          <h4>Transformation (ecdsa-sd-2023)</h4>
+
+          <p>
+The following algorithm specifies how to transform an unsecured input document
+into a transformed document that is ready to be provided as input to the
+hashing algorithm in Section <a href="#hashing-ecdsa-sd-2023"></a>.
+          </p>
+
+          <p>
+Required inputs to this algorithm are an
+<a data-cite="vc-data-integrity#dfn-unsecured-data-document">
+unsecured data document</a> (<var>unsecuredDocument</var>) and
+transformation options (<var>options</var>). The
+transformation options MUST contain a type identifier for the
+<a data-cite="vc-data-integrity#dfn-cryptosuite">
+cryptographic suite</a> (<var>type</var>) and a cryptosuite
+identifier (<var>cryptosuite</var>). A <em>transformed data document</em> is
+produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
+encoding.
+          </p>
+
+          <ol class="algorithm">
+
+          </ol>
         </section>
+
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1799,6 +1799,78 @@ Return <em>framedDocument</em>.
           </ol>
         </section>
 
+        <section>
+          <h4>groupNquads</h4>
+
+          <p>
+The following algorithm groups N-Quads into matching and non-matching groups.
+The inputs are an array of N-Quads (<var>nquads</var>, an optional skolemized
+JSON-LD document (<var>skolemizedDocument</var>), an optional JSON-LD frame
+(<var>frame</var>) , and any options, such as a document loader, to be passed to
+JSON-LD APIs. Each of the output groups (matching and non-matching) are
+expressed as a map that maps an index into <var>nquads<var> to the N-Quad value.
+This algorithm uses a JSON-LD frame to match specific N-Quads in the array of
+given <var>nquads</var>. It internally skolemizes and then deskolemizes any
+blank nodes around the framing operation to ensure blank node identifiers do not
+change, preventing the matching operation from working properly.
+An object containing a <em>matching</em> and <em>nonmatching</em> arrays of
+N-Quads are generated as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `matching` to an empty map.
+            </li>
+            <li>
+Initialize `nonMatching` to an empty map.
+            </li>
+            <li>
+If `frame` is not given or `null`, then there are no matches so:
+              <ol class="algorithm">
+                <li>
+Add each entry (index, element) in `nquads` to `nonMatching`.
+                </li>
+                <li>
+Return an object with "matching" set to `matching` and "nonMatching" set to
+`nonMatching`.
+                </li>
+              </ol>
+            </li>
+            <li>
+If `skolemizedDocument` has not been given: Set `skolemizedDocument` to the
+result of calling "createSkolemizedDocument", passing `nquads` and any custom
+JSON-LD API options (such as a document loader).
+            </li>
+            <li>
+Initialize `framed` to the result of calling "strictFrame", passing
+`skolemizedDocument`, `frame`, and any custom JSON-LD API options. Note: This
+step filters the skolemized document to get only data that matches the frame as
+a new JSON-LD document.
+            </li>
+            <li>
+Initialize `matchingDeskolemized` to the result of calling "toDeskolemizedRDF",
+passing `framed` and any custom JSON-LD API options. Note: This step converts
+any matching data back to deskolemized N-Quads, matching their original
+expression.
+            </li>
+            <li>
+For each entry (`index`, `nq`) in `nquads`:
+              <ol class="algorithm">
+                <li>
+If `matchingDeskolemized` includes `nq`, add the entry to `matching`.
+                </li>
+                <li>
+Otherwise, add the entry to `nonMatching`.
+                </li>
+              </ol>
+            </li>
+            <li>
+Return an object with "matching" set to `matching` and "nonMatching" set to
+`nonMatching`.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -2726,6 +2726,72 @@ Return `revealDocument` as the <em>selectively revealed document</em>.
 
         </section>
 
+        <section>
+          <h4>Verify Derived Proof (ecdsa-sd-2023)</h4>
+
+          <p>
+The following algorithm attempts verification of an `ecdsa-sd-2023` derived
+proof. This algorithm is called by a verifier of an ECDSA-SD-protected
+<a>verifiable credential</a>. The inputs include a JSON-LD document
+(<var>document</var>), an ECDSA-SD disclosure proof (<var>proof</var>), and any
+custom JSON-LD API options, such as a document loader. A single boolean
+<em>verification result</em> value is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `baseSignature`, `proofHash`, `publicKey`, `signatures`,
+`nonMandatory`, and `mandatoryHash` to the values associated with their property
+names in the object returned when calling the algorithm in Section
+<a href="#serializesigndata"></a>, passing the `document`, `proof`, and any
+custom JSON-LD API options, such as a document loader.
+            </li>
+            <li>
+If the length of `signatures` does not match the length of `nonMandatory`, throw
+an error indicating that the signature count does not match the non-mandatory
+message count.
+            </li>
+            <li>
+Initialize `publicKeyBytes` to the public key bytes expressed in `publicKey`.
+Instructions on how to decode the public key value can be found in Section
+<a href="#multikey"></a>.
+            </li>
+            <li>
+Initialize `toVerify` to the result of calling the algorithm in Setion
+<a href="#serializesigndata"></a>, passing `proofHash`, `publicKey`, and
+`mandatoryHash`.
+            </li>
+            <li>
+Initialize `verificationResult` be the result of applying the verification
+algorithm of the Elliptic Curve Digital Signature Algorithm (ECDSA) [FIPS-186-5],
+with `toVerify` as the data to be verified against the `baseSignature` using
+the public key specified by `publicKeyBytes`. If `verificationResult` is
+`false`, return `false`.
+            </li>
+            <li>
+For every entry (`index`, `signature`) in `signatures`, verify every signature
+for every selectively disclosed (non-mandatory) statement:
+              <ol class="algorithm">
+                <li>
+Initialize `verificationResult` to the result of applying the verification
+algorithm Elliptic Curve Digital Signature Algorithm (ECDSA) [FIPS-186-5], with
+the UTF-8 representation of the value at `index` of `nonMandatory` as the data
+to be verified against `signature` using the public key specified by
+`publicKeyBytes`.
+                </li>
+                <li>
+If `verificationResult` is `false`, return `false`.
+                </li>
+              </ol>
+            </li>
+
+            <li>
+Return `verificationResult` as <em>verification result</em>.
+            </li>
+          </ol>
+
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -2249,6 +2249,52 @@ starting with "u" and ending with the base64url-no-pad-encoded value of
 
         </section>
 
+        <section>
+          <h4>parseDerivedProofValue</h4>
+
+          <p>
+The following algorithm parses the components of the derived proof value.
+The required inputs are a derived proof value (<var>proofValue</var>). A
+A single <em>derived proof value</em> value object is produced as output, which
+contains a set to five elements, using the names "baseSignature", "publicKey",
+"signatures", "labelMap", and "mandatoryIndexes".
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Ensure the `proofValue` string starts with `u`, indicating that it is a
+multibase-base64url-no-pad-encoded value, throwing an error if it does not.
+            </li>
+            <li>
+Initialize `decodedProofValue` to the result of base64url-no-pad-decoding the
+substring after the leading `u` in `proofValue`.
+            </li>
+            <li>
+Ensure that the `decodedProofValue` starts with the ECDSA-SD disclosure proof
+header bytes `0xd9`, `0x5d`, and `0x01`, throwing an error if it does not.
+            </li>
+            <li>
+Initialize `components` to an array that is the result of CBOR-decoding the
+bytes that follow the three-byte ECDSA-SD disclosure proof header. Ensure the
+result is an array of five elements. Ensure the result is an array of five
+elements: a byte array of length 64, a byte array of length 36, an array of byte
+arrays, each of length 64, a map of integers to byte arrays of length 32, and an
+array of integers, throwing an error if not.
+            </li>
+            <li>
+Replace the fourth element in `components` using the result of calling the
+algorithm in Section <a href="#decompresslabelmap"></a>, passing the existing
+fourth element of `components` as `compressedLabelMap`.
+            </li>
+            <li>
+Return <em>derived proof value</em> as an object with properties set to the five
+elements, using the names "baseSignature", "publicKey", "signatures",
+"labelMap", and "mandatoryIndexes", respectively.
+            </li>
+          </ol>
+
+        </section>
+
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -2039,8 +2039,29 @@ encoding.
           </ol>
         </section>
 
+        <section>
+          <h4>Hashing (ecdsa-sd-2023)</h4>
 
-      </section>
+          <p>
+The following algorithm specifies how to cryptographically hash a
+<em>transformed data document</em> and <em>proof configuration</em>
+into cryptographic hash data that is ready to be provided as input to the
+algorithms in Section <a href="#proof-serialization-ecdsa-sd-2023"></a> or
+Section <a href="#proof-verification-ecdsa-sd-2023"></a>.
+          </p>
+
+          <p>
+The required inputs to this algorithm are a <em>transformed data document</em>
+(<var>transformedDocument</var>) and <em>canonical proof configuration</em>
+(<var>canonicalProofConfig</var>). A single <em>hash data</em> value represented as
+series of bytes is produced as output.
+          </p>
+
+          <ol class="algorithm">
+
+          </ol>
+
+        </section>
 
     </section>
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -2751,7 +2751,7 @@ custom JSON-LD API options, such as a document loader. A single boolean
 Initialize `baseSignature`, `proofHash`, `publicKey`, `signatures`,
 `nonMandatory`, and `mandatoryHash` to the values associated with their property
 names in the object returned when calling the algorithm in Section
-<a href="#serializesigndata"></a>, passing the `document`, `proof`, and any
+<a href="#createverifydata"></a>, passing the `document`, `proof`, and any
 custom JSON-LD API options, such as a document loader.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -1305,7 +1305,16 @@ Return <var>verificationResult</var> as the <em>verification result</em>.
       </section>
 
       <section>
-        <h4>Selective Disclosure Primitives</h4>
+        <h4>Selective Disclosure Functions</h4>
+
+        <p class="issue" title="(AT RISK) Pending implementation feedback and security reviews.">
+The Working Group is seeking implementer feedback on these generalized selective
+disclosure functions as well as horizonal security review on the features from
+parties at W3C and IETF. Those reviews might result in significant changes to
+these functions, migration of these functions to the core Data Integrity
+specification (for use by other cryptographic suites), or the removal of the
+algorithm from the specification during the Candidate Recommendation phase.
+        </p>
 
         <p>
 The following section contains a set of functions that are used throughout

--- a/index.html
+++ b/index.html
@@ -1959,6 +1959,74 @@ Return `mandatoryHash`.
         </section>
       </section>
 
+
+      <section>
+        <h3>ecdsa-sd-2023 Functions</h3>
+
+        <p>
+This section contains subalgorithms that are useful to the `ecdsa-sd-2023`
+cryptographic suite.
+        </p>
+
+        <section>
+          <h4>serializeSignData</h4>
+
+          <p>
+The following algorithm serializes the data that is to be signed by the private
+key associated with the base proof verification method. The required inputs are
+the proof options hash (<var>proofHash</var>), the proof-scoped multikey-encoded
+public key (<var>publicKey</var>), and the mandatory hash
+(<var>mandatoryHash</var>). A single <em>sign data</em> value,
+represented as series of bytes, is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Return the concatenation of <var>proofHash</var>, <var>publicKey</var>, and
+<var>mandatoryHash</var>, in that order, as <em>sign data</em>.
+            </li>
+          </ol>
+
+        </section>
+
+        <section>
+          <h4>serializeBaseProofValue</h4>
+
+          <p>
+The following algorithm serializes the base proof value, including the
+base signature, public key, HMAC key, signatures, and mandatory pointers.
+The required inputs are a base signature <var>baseSignature</var>, a public key
+<var>publicKey</var>, an HMAC key <var>hmacKey</var>, an array of
+<var>signatures</var>, and an array of <var>mandatoryPointers</var>.
+A single <em>base proof</em> string value is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize a byte array, `proofValue`, that starts with the ECDSA-SD base proof
+header bytes 0xd9, 0x5d, and 0x00.
+            </li>
+            <li>
+Initialize `components` to an array with five elements containing the values of:
+`baseSignature`, `publicKey`, `hmacKey`, `signatures`, and `mandatoryPointers`.
+            </li>
+            <li>
+CBOR-encode `components` and append it to `proofValue`.
+            </li>
+            <li>
+Initialize `baseProof` to a string with the multibase-base64url-no-pad-encoding
+of `proofValue`. That is, return a string starting with "u" and ending with the
+base64url-no-pad-encoded value of `proofValue`.
+            </li>
+            <li>
+Return `baseProof` as <em>base proof</em>.
+            </li>
+          </ol>
+
+        </section>
+
+      </section>
+
       <section>
         <h3>ecdsa-sd-2023</h3>
 
@@ -2178,63 +2246,6 @@ Return <var>canonicalProofConfig</var>.
         </section>
 
         <section>
-          <h4>serializeSignData</h4>
-
-          <p>
-The following algorithm serializes the data that is to be signed by the private
-key associated with the base proof verification method. The required inputs are
-the proof options hash (<var>proofHash</var>), the proof-scoped multikey-encoded
-public key (<var>publicKey</var>), and the mandatory hash
-(<var>mandatoryHash</var>). A single <em>sign data</em> value,
-represented as series of bytes, is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Return the concatenation of <var>proofHash</var>, <var>publicKey</var>, and
-<var>mandatoryHash</var>, in that order, as <em>sign data</em>.
-            </li>
-          </ol>
-
-        </section>
-
-        <section>
-          <h4>serializeBaseProofValue</h4>
-
-          <p>
-The following algorithm serializes the base proof value, including the
-base signature, public key, HMAC key, signatures, and mandatory pointers.
-The required inputs are a base signature <var>baseSignature</var>, a public key
-<var>publicKey</var>, an HMAC key <var>hmacKey</var>, an array of
-<var>signatures</var>, and an array of <var>mandatoryPointers</var>.
-A single <em>base proof</em> string value is produced as output.
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Initialize a byte array, `proofValue`, that starts with the ECDSA-SD base proof
-header bytes 0xd9, 0x5d, and 0x00.
-            </li>
-            <li>
-Initialize `components` to an array with five elements containing the values of:
-`baseSignature`, `publicKey`, `hmacKey`, `signatures`, and `mandatoryPointers`.
-            </li>
-            <li>
-CBOR-encode `components` and append it to `proofValue`.
-            </li>
-            <li>
-Initialize `baseProof` to a string with the multibase-base64url-no-pad-encoding
-of `proofValue`. That is, return a string starting with "u" and ending with the
-base64url-no-pad-encoded value of `proofValue`.
-            </li>
-            <li>
-Return `baseProof` as <em>base proof</em>.
-            </li>
-          </ol>
-
-        </section>
-
-        <section>
           <h4>Base Proof Serialization (ecdsa-sd-2023)</h4>
 
           <p>
@@ -2305,6 +2316,10 @@ Return `proofValue` as <em>digital proof</em>.
             </li>
           </ol>
 
+        </section>
+
+        <section>
+          <h4>Add Derived Proof (ecdsa-sd-2023)</h4>
         </section>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -2211,6 +2211,34 @@ label map (<var>labelMap</var>). The output is a <em>compressed label map</em>.
         </section>
 
         <section>
+          <h4>decompressLabelMap</h4>
+
+          <p>
+The following algorithm decompresses a label map. The required input is a
+compressed label map (<var>compressedLabelMap</var>). The output is a
+<em>decompressed label map</em>.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `map` to an empty map.
+              </li>
+              <li>
+For each entry (`k`, `v`) in `compressedLabelMap`:
+                <ol class="algorithm">
+                  <li>
+Add an entry to `map` with a key that adds the prefix "c14n" to `k` and a value
+that adds a prefix of "u" to the base64url-no-pad-encoded value for `v`.
+                  </li>
+                </ol>
+              <li>
+Return `map` as <em>decompressed label map</em>.
+              </li>
+          </ol>
+
+        </section>
+
+        <section>
           <h4>serializeDerivedProofValue</h4>
 
           <p>

--- a/index.html
+++ b/index.html
@@ -2287,7 +2287,7 @@ coordinate of the public key).
             </li>
             <li>
 Initialize `toSign` to the result of calling the algorithm in Section
-<a href="#serializebasesigndata"></a>, passing `proofHash`, `publicKey`, and
+<a href="#serializesigndata"></a>, passing `proofHash`, `publicKey`, and
 `mandatoryHash` as parameters to the algorithm.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -2063,6 +2063,123 @@ respectively.
 
         </section>
 
+        <section>
+          <h4>createDisclosureData</h4>
+
+          <p>
+The following algorithm creates data to be used to generate a derived proof. The
+inputs include a JSON-LD document (<var>document</var>), an ECDSA-SD base proof
+(<var>proof</var>), an array of JSON pointers to use to selectively disclose
+statements (<var>selectivePointers</var>), and any custom JSON-LD API options,
+such as a document loader). A single object, <em>disclosure data</em>, is
+produced as output, which contains the "baseSignature", "publicKey",
+"signatures" for "filteredSignatures", "labelMap", "mandatoryIndexes", and
+"revealDocument" fields.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `baseSignature`, `publicKey`, `hmacKey`, `signatures`, and
+`mandatoryPointers` to the values of the associated properties in the object
+returned when calling the algorithm in Section
+<a href="#parsebaseproofvalue"></a>, passing the `proofValue` from `proof`.
+            </li>
+            <li>
+Initialize `hmac` to an HMAC API using `hmacKey`. The HMAC uses the same hash
+algorithm used in the signature algorithm, i.e., SHA-256 for a P-256 curve.
+            </li>
+            <li>
+Initialize `nquads` to the result of calling the algorithm in Section
+<a href="#hmacidcanonize"></a>, passing `document`, `hmac`, and any custom
+JSON-LD API options as parameters. Note: This step transforms the document into
+an array of canonical N-Quads with pseudorandom blank node identifiers based on
+`hmac`.
+            </li>
+            <li>
+Initialize `mandatoryFrame` to the result of calling the algorithm in Section <a
+href="#jsonpointerstoframe"></a>, passing `document` and `mandatoryPointers` as
+`pointers`.
+            </li>
+            <li>
+Initialize `combinedFrame` to the result of calling the
+<a href="#jsonpointerstoframe"></a> primitive, passing `document` and the
+concatenation of `mandatoryPointers` and `selectivePointers` as `pointers`.
+            </li>
+            <li>
+If `mandatoryFrame` and `combinedFrame` are both `null`, then throw an error
+indicating that nothing is to be disclosed.
+            </li>
+            <li>
+Execute the following two steps in parallel (if the runtime environment allows
+for parallel execution, otherwise, execute the operations serially):
+              <ol class="algorithm">
+                <li>
+Initialize `revealDocument` to the result of calling the algorithm in
+Section <a href="#strictframe"></a>, passing `document`, `combinedFrame` as
+`frame`, and any custom JSON-LD API options.
+                </li>
+                <li>
+Initialize `filterAndGroupResult` to the result of calling the algorithm in
+Section <a href="#filterandgroupnquads"></a>, passing `nquads`, `combinedFrame` for
+`filterFrame`, `mandatoryFrame` for `groupFrame`, and any custom JSON-LD API
+options.
+                </li>
+              </ol>
+            </li>
+            <li>
+Initialize `labelMap` to the value of "labelMap" in `filterAndGroupResult`.
+            </li>
+            <li>
+Initialize `relativeMandatory` to the value of "matching" in the value of
+"filtered" in `filterAndGroupResult`.
+            </li>
+            <li>
+Initialize `absoluteMandatory` to the value of "matching" in
+`filterAndGroupResult`.
+            </li>
+            <li>
+Initialize `absoluteNonMandatory` to the value of "nonMatching" in
+`filterAndGroupResult`.
+            </li>
+            <li>
+Initialize `mandatoryIndexes` to the keys from `relativeMandatory`.
+            </li>
+            <li>
+Choose the signatures that match the selectively disclosed statements, which
+requires shifting by any absolute mandatory indexes to cause the indexes in
+`signatures` to match with `absoluteNonMandatory` map keys:
+              <ol class="algorithm">
+                <li>
+Initialize `index` to `0`.
+                </li>
+                <li>
+Initialize `filteredSignatures` to an empty array.
+                </li>
+                <li>
+For each `signature` in `signatures`:
+                  <ol class="algorithm">
+                    <li>
+While `index` is in `absoluteMandatory`, increment `index`.
+                    </li>
+                    <li>
+If `index` is in `absoluteNonMandatory`, add `signature` to
+`filteredSignatures`.
+                    </li>
+                    <li>
+Increment `index`.
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+            <li>
+Return an object with properties matching `baseSignature`, `publicKey`,
+"signatures" for `filteredSignatures`, `labelMap`, `mandatoryIndexes`, and
+`revealDocument`.
+            </li>
+          </ol>
+
+        </section>
 
       </section>
 
@@ -2362,7 +2479,7 @@ Return `proofValue` as <em>digital proof</em>.
 
           <p>
 The following algorithm creates a selective disclosure derived proof; called by
-a <a>holder</a> of an `ecdsa-sd-2023`-protected <a>verifiable credential</a>.
+a holder of an `ecdsa-sd-2023`-protected <a>verifiable credential</a>.
 The derived proof is to be given to the <a>verifier</a>. The inputs include a
 JSON-LD document (<var>document</var>), an ECDSA-SD base proof
 (<var>proof</var>), an array of JSON pointers to use to selectively disclose

--- a/index.html
+++ b/index.html
@@ -2323,6 +2323,69 @@ elements, using the names "baseSignature", "publicKey", "signatures",
 
         </section>
 
+        <section>
+          <h4>createVerifyData</h4>
+
+          <p>
+The following algorithm creates the data needed to perform verification of an
+ECDSA-SD-protected <a>verifiable credential</a>. The inputs include a JSON-LD
+document (<var>document</var>), an ECDSA-SD disclosure proof (<var>proof</var>),
+and any custom JSON-LD API options, such as a document loader. A single
+<em>verify data</em> object value is produced as output containing the following
+fields: "baseSignature", "proofHash", "publicKey", "signatures", "nonMandatory",
+and "mandatoryHash".
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize `proofHash` to the result of perform RDF Dataset Canonicalization
+[[RDF-CANON]] on the proof options. The hash used is the same as the one used in
+the signature algorithm, i.e., SHA-256 for a P-256 curve. Note: This step can be
+performed in parallel; it only needs to be completed before this algorithm needs
+to use the `proofHash` value.
+            </li>
+            <li>
+Initialize `baseSignature`, `publicKey`, `signatures`, `labelMap`, and
+`mandatoryIndexes`, to the values associated with their property names in the
+object returned when calling the algorithm in Section
+<a href="#parsederivedproofvalue"></a>, passing `proofValue` from `proof`.
+            </li>
+            <li>
+Initialize `nquads` to the result of calling the "labelReplacementCanonize"
+primitive, passing `document`, the result of calling the "labelMapCanonize"
+primitive (passing `labelMap`) as `labelReplacementFunction`, and any custom
+JSON-LD API options. Note: This step transforms the document into an array of
+canonical N-Quads with pseudorandom blank node identifiers based on `labelMap`.
+            </li>
+            <li>
+Initialize `mandatory` to an empty array.
+            </li>
+            <li>
+Initialize `nonMandatory` to an empty array.
+            </li>
+            <li>
+For each entry (`index`, `nq`) in `nquads`, separate the N-Quads into mandatory
+and non-mandatory categories:
+            <ol class="algorithm">
+              <li>
+If `mandatoryIndexes` includes `index`, add `nq` to `mandatory`.
+              </li>
+              <li>
+Otherwise, add `nq` to `nonMandatory`.
+              </li>
+            </ol>
+            <li>
+Initialize `mandatoryHash` to the result of calling the "hashMandatory"
+primitive, passing `mandatory`.
+            </li>
+            <li>
+Return an object with properties matching `baseSignature`, `proofHash`,
+`publicKey`, `signatures`, `nonMandatory`, and `mandatoryHash`.
+            </li>
+          </ol>
+
+        </section>
+
       </section>
 
       <section>


### PR DESCRIPTION
This PR adds the ecdsa-sd-2023 cryptosuite to the ECDSA Cryptosuites specification. This cryptographic suite was introduced to the W3C CCG and VCWG here: 

https://lists.w3.org/Archives/Public/public-credentials/2023May/0104.html

A presentation providing a background on the cryptosuite is available here:

https://docs.google.com/presentation/d/1d-04kIWhPuNscsAyUuRH3pduqrNerhigCWahKe6SNos/edit#

A complete open source implementation, with complete API documentation, exists here (with more implementations on the way):

https://github.com/digitalbazaar/ecdsa-sd-2023-cryptosuite

This PR is raised as a result of stated support by W3C Members in this group, three global standards organizations (two of whom are members of the VCWG), and a number of implementers: https://lists.w3.org/Archives/Public/public-vc-wg/2023Jul/0015.html

The cryptosuite is marked as "at risk" and may be removed from the specification if there are not enough implementations demonstrated during the Candidate Recommendation phase or if there is consensus to remove it from the specification for technical reasons before the Recommendation phase.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/pull/20.html" title="Last updated on Aug 3, 2023, 12:40 PM UTC (fbcf303)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/20/9308063...fbcf303.html" title="Last updated on Aug 3, 2023, 12:40 PM UTC (fbcf303)">Diff</a>