### PR TITLE
Mitigate poison datasets in ECDSA when canonicalizing.

### DIFF
--- a/index.html
+++ b/index.html
@@ -457,6 +457,12 @@ resulting in the production of a data integrity proof. The algorithms in this
 section also include the verification of such a data integrity proof.
         </p>
 
+        <p class="advisement">
+When the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] is utilized,
+implementations MUST detect <a data-cite="RDF-CANON#dataset-poisoning">
+dataset poisoning</a> by default and abort processing.
+        </p>
+
         <section>
           <h4>Add Proof (ecdsa-2019)</h4>
 

--- a/index.html
+++ b/index.html
@@ -459,8 +459,9 @@ section also include the verification of such a data integrity proof.
 
         <p class="advisement">
 When the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] is used,
-implementations MUST detect <a data-cite="RDF-CANON#dataset-poisoning">
-dataset poisoning</a> by default, and abort processing upon detection.
+implementations of that algorithm MUST detect 
+<a data-cite="RDF-CANON#dataset-poisoning">dataset poisoning</a> 
+by default, and abort processing upon detection.
         </p>
 
         <section>

--- a/index.html
+++ b/index.html
@@ -458,9 +458,9 @@ section also include the verification of such a data integrity proof.
         </p>
 
         <p class="advisement">
-When the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] is utilized,
+When the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] is used,
 implementations MUST detect <a data-cite="RDF-CANON#dataset-poisoning">
-dataset poisoning</a> by default and abort processing.
+dataset poisoning</a> by default, and abort processing upon detection.
         </p>
 
         <section>


### PR DESCRIPTION
This PR implements a new requirement to detect dataset poisoning by default in VC Data Integrity PR https://github.com/w3c/vc-data-integrity/pull/128


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/pull/21.html" title="Last updated on Aug 5, 2023, 9:56 PM UTC (973728e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/21/f7b1f73...973728e.html" title="Last updated on Aug 5, 2023, 9:56 PM UTC (973728e)">Diff</a>