### PR TITLE
Change poison graph mitigation into advisement

### DIFF
--- a/index.html
+++ b/index.html
@@ -461,7 +461,7 @@ section also include the verification of such a data integrity proof.
 
         <p class="advisement">
 When the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] is used,
-implementations of that algorithm MUST detect
+implementations of that algorithm will detect
 <a data-cite="RDF-CANON#dataset-poisoning">dataset poisoning</a>
 by default, and abort processing upon detection.
         </p>


### PR DESCRIPTION
This PR changes the dataset poisoning into an advisement, not a normative statement due to objections to merge a duplicative normative statement in https://github.com/w3c/vc-di-eddsa/pull/51


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/pull/24.html" title="Last updated on Aug 17, 2023, 6:47 PM UTC (3f92e76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/24/6f9b3fa...3f92e76.html" title="Last updated on Aug 17, 2023, 6:47 PM UTC (3f92e76)">Diff</a>