### PR TITLE
Simplify language that warns of invalid examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,8 +252,8 @@ non-conforming documents are consumed.
 This document contains examples of JSON and JSON-LD data. Some of these examples
 are invalid JSON, as they include features such as inline comments (`//`)
 explaining certain portions and ellipses (`...`) indicating the omission of
-information that is irrelevant to the example. These parts would have to be
-removed in order to treat the examples as valid JSON or JSON-LD.
+information that is irrelevant to the example. Such parts need to be
+removed if implementers want to treat the examples as valid JSON or JSON-LD.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -248,13 +248,12 @@ as software and/or hardware that generates or consumes a
 <a>conforming proof</a>. Conforming processors MUST produce errors when
 non-conforming documents are consumed.
         </p>
-        <p>
-This document also contains examples that contain JSON and JSON-LD content. Some
-of these examples contain characters that are invalid JSON, such as inline
-comments (`//`) and the use of ellipsis (`...`) to denote
-information that adds little value to the example. Implementers are cautioned to
-remove this content if they desire to use the information as valid JSON or
-JSON-LD.
+	<p>
+This document contains examples of JSON and JSON-LD data. Some of these examples
+are invalid JSON, as they include features such as inline comments (`//`)
+explaining certain portions and ellipses (`...`) indicating the omission of
+information that is irrelevant to the example. These parts would have to be
+removed in order to treat the examples as valid JSON or JSON-LD.
         </p>
       </section>
 


### PR DESCRIPTION
This commit contains a minor improvement to a paragraph early in the specification. See also <https://github.com/w3c/vc-di-eddsa/pull/59>.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/seabass-labrax/vc-di-ecdsa/pull/31.html" title="Last updated on Sep 2, 2023, 9:18 PM UTC (5f68c93)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/31/8bdbbab...seabass-labrax:5f68c93.html" title="Last updated on Sep 2, 2023, 9:18 PM UTC (5f68c93)">Diff</a>