### PR TITLE
Add pointers back to Data Integrity Privacy and Security Considerations sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -2660,6 +2660,14 @@ improving the chances of maximum interoperability for the multikey format.
 
     <section>
       <h2>Privacy Considerations</h2>
+
+      <p class="advisement">
+Before reading this section, readers are urged to familiarize themselves
+with general privacy advice provided in the
+<a href="https://www.w3.org/TR/vc-data-integrity/#privacy-considerations">
+Privacy Considerations section of the Data Integrity specification</a>.
+      </p>
+
       <p>
 The following section describes privacy considerations that developers
 implementing this specification should be aware of in order to avoid violating

--- a/index.html
+++ b/index.html
@@ -2527,32 +2527,41 @@ Return `verificationResult` as <em>verification result</em>.
     </section>
     <section class="informative">
       <h2>Security Considerations</h2>
-      <p>
-The security (integrity/authenticity) of a verifiable credential
-signed by a digital signature algorithm is dependent on a number of factors
-including:
+
+      <p class="advisement">
+Before reading this section, readers are urged to familiarize themselves
+with general security advice provided in the
+<a href="https://www.w3.org/TR/vc-data-integrity/#security-considerations">
+Security Considerations section of the Data Integrity specification</a>.
       </p>
+
+      <p>
+The integrity and authenticity of a secured document that is protected by
+this cryptographic suite is dependent on a number of factors including:
+      </p>
+
       <ul>
         <li>
-the correct application of the signature algorithm to a verifiable
-credential (this specification)
+the correct application of a digital signature to a document,
         </li>
         <li>
-the choice of signature algorithm (ECDSA) and its parameters (P-256, P-384)
+the choice of signature algorithm (ECDSA) and its parameters (P-256, P-384),
         </li>
         <li>
-the correct implementation and usage of the signature algorithm,
-particularly with respect to well-known problem areas
+the correct implementation and usage of the digital signature algorithm,
+particularly with respect to well-known problem areas, and
         </li>
         <li>
 the proper management of the private and public keys used for
-signing and verification
+signing and verification.
         </li>
       </ul>
+
       <p>
 In the following sections, we review these important points and direct
 the reader to additional information.
       </p>
+
       <section class="informative">
         <h3>Choice of ECDSA and Parameters</h3>
         <p>

--- a/index.html
+++ b/index.html
@@ -2537,23 +2537,25 @@ Security Considerations section of the Data Integrity specification</a>.
 
       <p>
 The integrity and authenticity of a secured document that is protected by
-this cryptographic suite is dependent on a number of factors including:
+this cryptographic suite is dependent on a number of factors including
+the following:
       </p>
 
       <ul>
         <li>
-the correct application of a digital signature to a document,
+correct application of a digital signature to the document
         </li>
         <li>
-the choice of signature algorithm (ECDSA) and its parameters (P-256, P-384),
+choice of an appropriate signature algorithm (ECDSA) and its parameters
+(P-256, P-384)
         </li>
         <li>
-the correct implementation and usage of the digital signature algorithm,
-particularly with respect to well-known problem areas, and
+correct implementation and usage of the digital signature algorithm,
+particularly with respect to well-known problem areas
         </li>
         <li>
-the proper management of the private and public keys used for
-signing and verification.
+proper management of the private and public keys used for
+signing and verification
         </li>
       </ul>
 


### PR DESCRIPTION
This PR attempts to address issue #29, raised by the PING and security review, by pointing back to the Data Integrity Security and Privacy Considerations section.

/cc @kdenhartog


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/pull/33.html" title="Last updated on Aug 26, 2023, 6:44 PM UTC (ab64324)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/33/a9f2510...ab64324.html" title="Last updated on Aug 26, 2023, 6:44 PM UTC (ab64324)">Diff</a>