### PR TITLE
deterministic ECDSA SHOULD be used

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@ match the verification relationship expressed by the verification method
 `controller`.
           </p>
           <p>
-The `proofValue` property of the proof MUST be an ECDSA signature produced
+The value of the `proofValue` property of the proof MUST be an ECDSA signature produced
 according to [[FIPS-186-5]] and SHOULD use the <em>deterministic</em> ECDSA
 signature variant, produced according to [[FIPS-186-5]] using the curves and
 hashes as specified in section <a href="#algorithms"></a>, encoded according to

--- a/index.html
+++ b/index.html
@@ -408,12 +408,12 @@ match the verification relationship expressed by the verification method
 `controller`.
           </p>
           <p>
-The `proofValue` property of the proof MUST be an ECDSA signature, in general,
-and SHOULD be a <em>deterministic</em> ECDSA signature, specific variant,
-produced according to [[FIPS-186-5]] using the curves and hashes as
-specified in section <a href="#algorithms"></a>, encoded according to section 7
-of [[RFC4754]] (sometimes referred to as the IEEE P1363 format), and serialized
-according to [[MULTIBASE]] using the base58-btc base encoding.
+The `proofValue` property of the proof MUST be an ECDSA signature produced
+according to [[FIPS-186-5]] and SHOULD use the <em>deterministic</em> ECDSA
+signature variant, produced according to [[FIPS-186-5]] using the curves and
+hashes as specified in section <a href="#algorithms"></a>, encoded according to
+section 7 of [[RFC4754]] (sometimes referred to as the IEEE P1363 format), and
+serialized according to [[MULTIBASE]] using the base58-btc base encoding.
           </p>
 
           <pre class="example nohighlight"
@@ -447,7 +447,7 @@ according to [[MULTIBASE]] using the base58-btc base encoding.
       <p>
 The following section describes multiple Data Integrity cryptographic suites
 that utilize the Elliptic Curve Digital Signature Algorithm (ECDSA) [[FIPS-186-5]].
-When generating ECDSA signatures the <em>deterministic</em> ECDSA algorithm
+When generating ECDSA signatures, the <em>deterministic</em> ECDSA algorithm
 variant SHOULD be used.
       </p>
 
@@ -2594,11 +2594,11 @@ of each digital signature for use during the signature generation process.&quot;
 The failure to properly generate this <em>k</em> value has lead to some highly
 publicized integrity breaches in widely deployed systems. To counter this problem,
 a hash-based method of determining the secret number <em>k</em>, called
-<em>Deterministic ECDSA</em>, is given in [[FIPS-186-5]] and [[RFC6979]].
+<em>deterministic ECDSA</em>, is given in [[FIPS-186-5]] and [[RFC6979]].
         </p>
         <p>
 Verification of a ECDSA signature is independent of the method of generating
-<em>k</em>. Hence it is generally recommended to use <em>Deterministic
+<em>k</em>. Hence it is generally recommended to use <em>deterministic
 ECDSA</em> unless other requirements dictate otherwise. For example, using
 different <em>k</em> values results in different signature values for the same
 document which may be a desirable property in some privacy enhancing situations.
@@ -2670,7 +2670,7 @@ privacy assumptions.
     <section class="appendix informative">
       <h2>Test Vectors</h2>
       <p class="note">
-All test vectors are produced using <em>Deterministic ECDSA</em>. The
+All test vectors are produced using <em>deterministic ECDSA</em>. The
 implementation was validated against the test vectors in [[RFC6979]].
       </p>
       <section>

--- a/index.html
+++ b/index.html
@@ -408,8 +408,9 @@ match the verification relationship expressed by the verification method
 `controller`.
           </p>
           <p>
-The `proofValue` property of the proof MUST be an ECDSA or deterministic ECDSA
-signature produced according to [[FIPS-186-5]] using the curves and hashes as
+The `proofValue` property of the proof MUST be an ECDSA signature, in general,
+and SHOULD be a <em>deterministic</em> ECDSA signature, specific variant,
+produced according to [[FIPS-186-5]] using the curves and hashes as
 specified in section <a href="#algorithms"></a>, encoded according to section 7
 of [[RFC4754]] (sometimes referred to as the IEEE P1363 format), and serialized
 according to [[MULTIBASE]] using the base58-btc base encoding.
@@ -446,6 +447,8 @@ according to [[MULTIBASE]] using the base58-btc base encoding.
       <p>
 The following section describes multiple Data Integrity cryptographic suites
 that utilize the Elliptic Curve Digital Signature Algorithm (ECDSA) [[FIPS-186-5]].
+When generating ECDSA signatures the <em>deterministic</em> ECDSA algorithm
+variant SHOULD be used.
       </p>
 
       <section>
@@ -2592,9 +2595,13 @@ The failure to properly generate this <em>k</em> value has lead to some highly
 publicized integrity breaches in widely deployed systems. To counter this problem,
 a hash-based method of determining the secret number <em>k</em>, called
 <em>Deterministic ECDSA</em>, is given in [[FIPS-186-5]] and [[RFC6979]].
+        </p>
+        <p>
 Verification of a ECDSA signature is independent of the method of generating
 <em>k</em>. Hence it is generally recommended to use <em>Deterministic
-ECDSA</em> unless other requirements dictate otherwise.
+ECDSA</em> unless other requirements dictate otherwise. For example, using
+different <em>k</em> values results in different signature values for the same
+document which may be a desirable property in some privacy enhancing situations.
         </p>
       </section>
       <section class="informative">


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-ecdsa/issues/28. To require that the *deterministic* ECDSA algorithm **SHOULD** be used. Previously we just had that the ECDSA algorithm **MUST** be used without explicitly pointing out the security advantages of the *deterministic* variant.

In the security considerations section has been slightly extended to offer a reason why, in some situations, one might not want to use the deterministic variant. This section already explains why in most cases one should use the deterministic variant.

Note that the security considerations section already points out that verification of signatures is the same for both variants.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/34.html" title="Last updated on Aug 23, 2023, 2:11 PM UTC (87095df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/34/a9f2510...Wind4Greg:87095df.html" title="Last updated on Aug 23, 2023, 2:11 PM UTC (87095df)">Diff</a>