### PR TITLE
Add which cryptographic hash function to use for RDF-CANON.

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,6 +449,22 @@ The following section describes multiple Data Integrity cryptographic suites
 that utilize the Elliptic Curve Digital Signature Algorithm (ECDSA) [[FIPS-186-5]].
       </p>
 
+      <p>
+Implementations SHOULD fetch and cache <a>verification method</a> information as
+early as possible when adding or verifying proofs. Parameters passed to
+functions in this section utilize information from the <a>verification
+method</a>, such as the public key size, to determine function parameters, such
+as the cryptographic hashing algorithm to utilize.
+      </p>
+
+      <p>
+When the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] is used with ECDSA
+algorithms, the cryptographic hashing function that is passed to the algorithm
+MUST be determined by the size of the associated public key. For P-256 keys,
+SHA-2 with 256 bits of output is utilized. For P-384 keys, SHA-2 with 384-bits
+of output is utilized.
+      </p>
+
       <p class="advisement">
 When the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] is used,
 implementations of that algorithm will detect

--- a/index.html
+++ b/index.html
@@ -452,9 +452,9 @@ that utilize the Elliptic Curve Digital Signature Algorithm (ECDSA) [[FIPS-186-5
       <p>
 Implementations SHOULD fetch and cache <a>verification method</a> information as
 early as possible when adding or verifying proofs. Parameters passed to
-functions in this section utilize information from the <a>verification
-method</a>, such as the public key size, to determine function parameters, such
-as the cryptographic hashing algorithm to utilize.
+functions in this section use information from the <a>verification
+method</a> — such as the public key size — to determine function parameters — such
+as the cryptographic hashing algorithm.
       </p>
 
       <p>


### PR DESCRIPTION
This PR attempts to address issue #32 by explicitly stating which hash function should be passed to RDF-CANON and stating that verification methods should be fetched and cached early in the process.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/pull/36.html" title="Last updated on Sep 2, 2023, 9:24 PM UTC (45178e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/36/83b87cd...45178e9.html" title="Last updated on Sep 2, 2023, 9:24 PM UTC (45178e9)">Diff</a>