### PR TITLE
Enhance description of skolemizeExpandedJsonLd, variable naming, id string

### DIFF
--- a/index.html
+++ b/index.html
@@ -1342,10 +1342,11 @@ Return <em>deskolemizedNQuads</em>.
 
           <p>
 The following algorithm replaces all blank node identifiers in an expanded
-JSON-LD document with custom-scheme URNs. The required inputs are an expanded
-JSON-LD document (<var>expanded</var>), a custom URN scheme
-(<var>urnScheme</var>), a UUID string or other comparably random string
-(<var>random</var>), and reference to a shared integer (<var>count</var>).
+JSON-LD document with custom-scheme URNs and assigns custom-scheme identifiers to
+blank nodes. The required inputs are an expanded JSON-LD document
+(<var>expanded</var>), a custom blank node prefix
+(<var>bnPrefix</var>), a UUID string or other comparably random string
+(<var>randomString</var>), and reference to a shared integer (<var>count</var>).
 Any additional custom options (such as a document loader) can also be passed.
 It produces the expanded form of the skolemized JSON-LD document
 (<var>skolemizedExpandedDocument</var> as output. The skolemization used in this
@@ -1355,7 +1356,7 @@ Section <a href="#todeskolemizednquads"></a>.
 
           <ol class="algorithm">
             <li>
-Initialize <var>skomelizedExpanded</var> to an empty array.
+Initialize <var>skolemizedExpandedDocument</var> to an empty array.
             </li>
             <li>
 For each <var>element</var> in <var>expanded</var>:
@@ -1387,15 +1388,15 @@ and keeping the other parameters the same.
                 <li>
 If <var>skolemizedNode</var> has no <em>@id</em> property, set the value of
 the <em>@id</em> property in <var>skolemizedNode</var> to the concatenation
-of "urn:", <var>urnScheme</var>, <var>random</var>, "_" and the value of
+of <var>bnPrefix</var>, "_",  <var>randomString</var>, "_" and the value of
 <var>count</var>, incrementing the value of <var>count</var> afterwards.
                 </li>
                 <li>
 Otherwise, if the value of the <em>@id</em> property in
 <var>skolemizedNode</var> starts with "_:", preserve the existing blank node
 identifier when skolemizing by setting the value of the <em>@id</em> property
-in <var>skolemizedNode</var> to the concatenation of "urn:",
-<var>urnScheme</var>, and the existing value of the <em>@id</em> property.
+in <var>skolemizedNode</var> to the concatenation of
+<var>bnPrefix</var>, and the existing value of the <em>@id</em> property.
                 </li>
                 <li>
 Append <var>skolemizedNode</var> to <var>skolemizedExpandedDocument</var>.

--- a/index.html
+++ b/index.html
@@ -1342,7 +1342,8 @@ Return <em>deskolemizedNQuads</em>.
 
           <p>
 The following algorithm replaces all blank node identifiers in an expanded
-JSON-LD document with custom-scheme URNs. The required inputs are an expanded JSON-LD document
+JSON-LD document with custom-scheme URNs, including assigning such URNs to
+blank nodes that are unlabeled. The required inputs are an expanded JSON-LD document
 (<var>expanded</var>), a custom URN scheme
 (<var>urnScheme</var>), a UUID string or other comparably random string
 (<var>randomString</var>), and reference to a shared integer (<var>count</var>).

--- a/index.html
+++ b/index.html
@@ -1342,10 +1342,9 @@ Return <em>deskolemizedNQuads</em>.
 
           <p>
 The following algorithm replaces all blank node identifiers in an expanded
-JSON-LD document with custom-scheme URNs and assigns custom-scheme identifiers to
-blank nodes. The required inputs are an expanded JSON-LD document
-(<var>expanded</var>), a custom blank node prefix
-(<var>bnPrefix</var>), a UUID string or other comparably random string
+JSON-LD document with custom-scheme URNs. The required inputs are an expanded JSON-LD document
+(<var>expanded</var>), a custom URN scheme
+(<var>urnScheme</var>), a UUID string or other comparably random string
 (<var>randomString</var>), and reference to a shared integer (<var>count</var>).
 Any additional custom options (such as a document loader) can also be passed.
 It produces the expanded form of the skolemized JSON-LD document
@@ -1388,15 +1387,15 @@ and keeping the other parameters the same.
                 <li>
 If <var>skolemizedNode</var> has no <em>@id</em> property, set the value of
 the <em>@id</em> property in <var>skolemizedNode</var> to the concatenation
-of <var>bnPrefix</var>, "_",  <var>randomString</var>, "_" and the value of
+of "urn:", <var>urnScheme</var>, "_",  <var>randomString</var>, "_" and the value of
 <var>count</var>, incrementing the value of <var>count</var> afterwards.
                 </li>
                 <li>
 Otherwise, if the value of the <em>@id</em> property in
 <var>skolemizedNode</var> starts with "_:", preserve the existing blank node
 identifier when skolemizing by setting the value of the <em>@id</em> property
-in <var>skolemizedNode</var> to the concatenation of
-<var>bnPrefix</var>, and the existing value of the <em>@id</em> property.
+in <var>skolemizedNode</var> to the concatenation of "urn:",
+<var>urnScheme</var>, and the existing value of the <em>@id</em> property.
                 </li>
                 <li>
 Append <var>skolemizedNode</var> to <var>skolemizedExpandedDocument</var>.


### PR DESCRIPTION
The function `skolemizeExpandedJsonLd` is a key primitive within the set of selective disclosure primitives. This PR contains:

1. An enhanced description of what this function does (important to promote understanding)
2. Small clarifying enhancements to variable naming
3. Fixes variable naming/use inconsistencies
4. Small fixes to blank node id generation to match that produced by libraries used to produced ECDSA-Test vectors (a missing underscore "_" in the format string)

@dlongley please review. I was able to recreate functionality from specification description and suggest these changes to help others.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/40.html" title="Last updated on Oct 2, 2023, 3:06 PM UTC (526edd7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/40/38f5c52...Wind4Greg:526edd7.html" title="Last updated on Oct 2, 2023, 3:06 PM UTC (526edd7)">Diff</a>