### PR TITLE
createInitialSelection: Fix parameter references.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1540,13 +1540,13 @@ JSON-LD object (<var>source</var>). A JSON-LD document fragment object
 Initialize <var>selection</var> to an empty object.
             </li>
             <li>
-If <var>value</var> has an `id` that is not a blank node identifier, set
+If <var>source</var> has an `id` that is not a blank node identifier, set
 `selection.id` to its value. Note: All non-blank node identifiers in the path of
 any JSON Pointer MUST be included in the selection, this includes any root
 document identifier.
             </li>
             <li>
-If <var>value</var>.`type` is set, set <var>selection</var>.`type` to its value.
+If <var>source</var>.`type` is set, set <var>selection</var>.`type` to its value.
 Note: The selection MUST include all `type`s in the path of any JSON Pointer,
 including any root document `type`.
             </li>


### PR DESCRIPTION
This PR fixes references to the parameters of the function `createInitialSelection`. @dlongley please review.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/41.html" title="Last updated on Sep 24, 2023, 4:12 PM UTC (548ca17)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/41/38f5c52...Wind4Greg:548ca17.html" title="Last updated on Sep 24, 2023, 4:12 PM UTC (548ca17)">Diff</a>