### PR TITLE
Fix skolemize existing blank node identifier bug.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1427,7 +1427,8 @@ Otherwise, if the value of the <em>@id</em> property in
 <var>skolemizedNode</var> starts with "_:", preserve the existing blank node
 identifier when skolemizing by setting the value of the <em>@id</em> property
 in <var>skolemizedNode</var> to the concatenation of "urn:",
-<var>urnScheme</var>, and the existing value of the <em>@id</em> property.
+<var>urnScheme</var>, and the blank node identifier (i.e., existing value of
+the <em>@id</em> property without the "_:" prefix).
                 </li>
                 <li>
 Append <var>skolemizedNode</var> to <var>skolemizedExpandedDocument</var>.

--- a/index.html
+++ b/index.html
@@ -1427,8 +1427,10 @@ Otherwise, if the value of the <em>@id</em> property in
 <var>skolemizedNode</var> starts with "_:", preserve the existing blank node
 identifier when skolemizing by setting the value of the <em>@id</em> property
 in <var>skolemizedNode</var> to the concatenation of "urn:",
-<var>urnScheme</var>, and the blank node identifier (i.e., existing value of
-the <em>@id</em> property without the "_:" prefix).
+<var>urnScheme</var>, and the blank node identifier (i.e., the existing
+value of the <em>@id</em> property minus the "_:" prefix; e.g., if the
+existing value of the <em>@id</em> property is `_:b0`, the blank node
+identifier is `b0`).
                 </li>
                 <li>
 Append <var>skolemizedNode</var> to <var>skolemizedExpandedDocument</var>.


### PR DESCRIPTION
This PR fixes a minor bug in the skolemization of an existing blank node identifier. The blank node identifier (e.g. `b0`) was meant to be preserved (as the text stated), but not its serialized form (`_:b0`). This fix ensures the value will be restored properly later.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dlongley/vc-di-ecdsa/pull/46.html" title="Last updated on Dec 19, 2023, 3:51 AM UTC (c36b762)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/46/0686d5b...dlongley:c36b762.html" title="Last updated on Dec 19, 2023, 3:51 AM UTC (c36b762)">Diff</a>