### PR TITLE
Edit algorithms to permit more general proof configuration options

### DIFF
--- a/index.html
+++ b/index.html
@@ -691,33 +691,17 @@ object is produced as output.
 
           <ol class="algorithm">
             <li>
-Let <var>proofConfig</var> be an empty object.
+Let <var>proofConfig</var> be a clone of the <var>options</var> object.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>type</var> to
-<var>options</var>.<var>type</var>.
-            </li>
-            <li>
-If <var>options</var>.<var>cryptosuite</var> is set, set
-<var>proofConfig</var>.<var>cryptosuite</var> to its value.
-            </li>
-            <li>
-If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
+If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and
 <var>proofConfig</var>.<var>cryptosuite</var> is not set to `ecdsa-rdfc-2019`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>created</var> to
-<var>options</var>.<var>created</var>. If the value is not a valid
-[[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
-            </li>
-            <li>
-Set <var>proofConfig</var>.<var>verificationMethod</var> to
-<var>options</var>.<var>verificationMethod</var>.
-            </li>
-            <li>
-Set <var>proofConfig</var>.<var>proofPurpose</var> to
-<var>options</var>.<var>proofPurpose</var>.
+If <var>proofConfig</var>.<var>created</var> is set and if the value is not a
+valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
+raised.
             </li>
             <li>
 Set <var>proofConfig</var>.<var>@context</var> to
@@ -979,33 +963,17 @@ object is produced as output.
 
           <ol class="algorithm">
             <li>
-Let <var>proofConfig</var> be an empty object.
+Let <var>proofConfig</var> be a clone of the <var>options</var> object.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>type</var> to
-<var>options</var>.<var>type</var>.
-            </li>
-            <li>
-If <var>options</var>.<var>cryptosuite</var> is set, set
-<var>proofConfig</var>.<var>cryptosuite</var> to its value.
-            </li>
-            <li>
-If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
+If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and
 <var>proofConfig</var>.<var>cryptosuite</var> is not set to `ecdsa-jcs-2019`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>created</var> to
-<var>options</var>.<var>created</var>. If the value is not a valid
-[[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
-            </li>
-            <li>
-Set <var>proofConfig</var>.<var>verificationMethod</var> to
-<var>options</var>.<var>verificationMethod</var>.
-            </li>
-            <li>
-Set <var>proofConfig</var>.<var>proofPurpose</var> to
-<var>options</var>.<var>proofPurpose</var>.
+If <var>proofConfig</var>.<var>created</var> is set and if the value is not a
+valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
+raised.
             </li>
             <li>
 Let <var>canonicalProofConfig</var> be the result of applying the
@@ -2590,33 +2558,17 @@ object is produced as output.
 
           <ol class="algorithm">
             <li>
-Let <var>proofConfig</var> be an empty object.
+Let <var>proofConfig</var> be a clone of the <var>options</var> object.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>type</var> to
-<var>options</var>.<var>type</var>.
-            </li>
-            <li>
-If <var>options</var>.<var>cryptosuite</var> is set, set
-<var>proofConfig</var>.<var>cryptosuite</var> to its value.
-            </li>
-            <li>
-If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
+If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and
 <var>proofConfig</var>.<var>cryptosuite</var> is not set to `ecdsa-sd-2023`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>
             <li>
-Set <var>proofConfig</var>.<var>created</var> to
-<var>options</var>.<var>created</var>. If the value is not a valid
-[[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
-            </li>
-            <li>
-Set <var>proofConfig</var>.<var>verificationMethod</var> to
-<var>options</var>.<var>verificationMethod</var>.
-            </li>
-            <li>
-Set <var>proofConfig</var>.<var>proofPurpose</var> to
-<var>options</var>.<var>proofPurpose</var>.
+If <var>proofConfig</var>.<var>created</var> is set and if the value is not a
+valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
+raised.
             </li>
             <li>
 Set <var>proofConfig</var>.<var>@context</var> to

--- a/index.html
+++ b/index.html
@@ -2561,7 +2561,7 @@ object is produced as output.
 Let <var>proofConfig</var> be a clone of the <var>options</var> object.
             </li>
             <li>
-If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and
+If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and/or
 <var>proofConfig</var>.<var>cryptosuite</var> is not set to `ecdsa-sd-2023`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>

--- a/index.html
+++ b/index.html
@@ -694,7 +694,7 @@ object is produced as output.
 Let <var>proofConfig</var> be a clone of the <var>options</var> object.
             </li>
             <li>
-If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and
+If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and/or
 <var>proofConfig</var>.<var>cryptosuite</var> is not set to `ecdsa-rdfc-2019`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>

--- a/index.html
+++ b/index.html
@@ -966,7 +966,7 @@ object is produced as output.
 Let <var>proofConfig</var> be a clone of the <var>options</var> object.
             </li>
             <li>
-If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and
+If <var>proofConfig</var>.<var>type</var> is not set to `DataIntegrityProof` and/or
 <var>proofConfig</var>.<var>cryptosuite</var> is not set to `ecdsa-jcs-2019`, an
 `INVALID_PROOF_CONFIGURATION` error MUST be raised.
             </li>


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-ecdsa/issues/48. It edits the document in three sections:

* Proof Configuration (ecdsa-rdfc-2019), 
* Proof Configuration (ecdsa-jcs-2019),
* Base Proof Configuration (ecdsa-sd-2023)

The changes are all similar. Instead of starting with an empty object the procedure starts with a clone of the proof options, this way any custom proof options are passed through for hashing and signing.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/49.html" title="Last updated on Jan 8, 2024, 10:50 PM UTC (5ee5ac1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/49/17742b3...Wind4Greg:5ee5ac1.html" title="Last updated on Jan 8, 2024, 10:50 PM UTC (5ee5ac1)">Diff</a>