### PR TITLE
Base proof properties on Data Integrity spec with restrictions

### DIFF
--- a/index.html
+++ b/index.html
@@ -746,11 +746,9 @@ represented as series of bytes is produced as output.
           <ol class="algorithm">
             <li>
 Let <var>privateKeyBytes</var> be the result of retrieving the
-private key bytes associated with the
-<var>options</var>.<var>verificationMethod</var> value as described in the
-Data Integrity [[VC-DATA-INTEGRITY]] specification,
-<a data-cite="vc-data-integrity#algorithms">
-Section 4: Retrieving Cryptographic Material</a>.
+private key bytes (or a signing interface enabling the use of the private key
+bytes) associated with the verification method identified by the
+<var>options</var>.<var>verificationMethod</var> value.
             </li>
             <li>
 Let <var>proofBytes</var> be the result of applying the Elliptic Curve Digital

--- a/index.html
+++ b/index.html
@@ -435,26 +435,15 @@ this specification.
           <h4>DataIntegrityProof</h4>
 
           <p>
-The `verificationMethod` property of the proof MUST be a URL.
-Dereferencing the `verificationMethod` MUST result in an object
-containing a `type` property with the value set to
-`Multikey`.
+A proof contains the attributes specified in the
+<a href="https://www.w3.org/TR/vc-data-integrity/#proofs">Proofs section</a>
+of [[VC-DATA-INTEGRITY]] with the following restrictions.
           </p>
-
           <p>
 The `type` property of the proof MUST be `DataIntegrityProof`.
           </p>
           <p>
 The `cryptosuite` property of the proof MUST be `ecdsa-rdfc-2019` or `ecdsa-jcs-2019`.
-          </p>
-          <p>
-The `created` property of the proof MUST be an [[XMLSCHEMA11-2]]
-formatted date string.
-          </p>
-          <p>
-The `proofPurpose` property of the proof MUST be a string, and MUST
-match the verification relationship expressed by the verification method
-`controller`.
           </p>
           <p>
 The value of the `proofValue` property of the proof MUST be an ECDSA signature


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-ecdsa/issues/47. The issue is "Ensure created proof option is optional". However *proof options* originate in the Data Integrity specification and the *created* property is properly defined as `optional` there. Hence this PR points back to the Data Integrity spec for *proof* property definitions and only elaborates on those properties that have restricted or specially defined values.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/50.html" title="Last updated on Jan 8, 2024, 5:31 PM UTC (23d04fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/50/17742b3...Wind4Greg:23d04fb.html" title="Last updated on Jan 8, 2024, 5:31 PM UTC (23d04fb)">Diff</a>