### PR TITLE
Add cryptographic suite instantiation algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,8 +536,7 @@ instance|cryptosuite instance=] ([=struct=] |cryptosuite|).
 Initialize |cryptosuite| to an empty [=struct=].
           </li>
           <li>
-If |options|.|type| does not equal `DataIntegrityProof`, an
-`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+If |options|.|type| does not equal `DataIntegrityProof`, return |cryptosuite|.
           </li>
           <li>
 If |options|.|cryptosuite| is `ecdsa-rdfc-2019` then:

--- a/index.html
+++ b/index.html
@@ -523,14 +523,14 @@ by default, and abort processing upon detection.
       </p>
 
       <section>
-        <h3>Suite Selection Algorithm</h3>
+        <h3>Instantiate Cryptosuite</h3>
 
         <p>
 This algorithm is used to configure a cryptographic suite to be used by the
-<a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">Add Proof</a> and
-<a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">Verify Proof</a>
+<a data-cite="VC-DATA-INTEGRITY#add-proof">Add Proof</a> and
+<a href="VC-DATA-INTEGRITY#verify-proof">Verify Proof</a>
 functions in [[[VC-DATA-INTEGRITY]]]. The algorithm takes an options object
-([=map=] |options|) as input and returns a cryptosuite
+([=map=] |options|) as input and returns a [=cryptosuite instance=]
 ([=struct=] |cryptosuite|).
         </p>
 
@@ -539,24 +539,15 @@ functions in [[[VC-DATA-INTEGRITY]]]. The algorithm takes an options object
 Initialize |cryptosuite| to an empty [=struct=].
           </li>
           <li>
-If |options|.|type| is `DataIntegrityProof` and |options|.|cryptosuite| is
-`ecdsa-rdfc-2019` then:
+If |options|.|type| does not equal `DataIntegrityProof`, an
+`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+          </li>
+          <li>
+If |options|.|cryptosuite| is `ecdsa-rdfc-2019` then:
             <ol class="algorithm">
               <li>
-Set |cryptosuite|.|transform| to the algorithm in Section
-<a href="#transformation-ecdsa-rdfc-2019"></a>.
-              </li>
-              <li>
-Set |cryptosuite|.|hash| to the algorithm in Section
-<a href="#hashing-ecdsa-rdfc-2019"></a>.
-              </li>
-              <li>
-Set |cryptosuite|.|createProofConfig| to the algorithm in Section
-<a href="#proof-configuration-ecdsa-rdfc-2019"></a>.
-              </li>
-              <li>
-Set |cryptosuite|.|serializeProof| to the algorithm in Section
-<a href="#proof-serialization-ecdsa-rdfc-2019"></a>.
+Set |cryptosuite|.|createProof| to the algorithm in Section
+<a href="#create-proof-ecdsa-rdfc-2019"></a>.
               </li>
               <li>
 Set |cryptosuite|.|verifyProof| to the algorithm in Section
@@ -565,24 +556,11 @@ Set |cryptosuite|.|verifyProof| to the algorithm in Section
             </ol>
           </li>
           <li>
-If |options|.|type| is `DataIntegrityProof` and |options|.|cryptosuite| is
-`ecdsa-jcs-2019` then:
+If |options|.|cryptosuite| is `ecdsa-jcs-2019` then:
             <ol class="algorithm">
               <li>
-Set |cryptosuite|.|transform| to the algorithm in Section
-<a href="#transformation-ecdsa-jcs-2019"></a>.
-              </li>
-              <li>
-Set |cryptosuite|.|hash| to the algorithm in Section
-<a href="#hashing-ecdsa-jcs-2019"></a>.
-              </li>
-              <li>
-Set |cryptosuite|.|createProofConfig| to the algorithm in Section
-<a href="#proof-configuration-ecdsa-jcs-2019"></a>.
-              </li>
-              <li>
-Set |cryptosuite|.|serializeProof| to the algorithm in Section
-<a href="#proof-serialization-ecdsa-jcs-2019"></a>.
+Set |cryptosuite|.|createProof| to the algorithm in Section
+<a href="#create-proof-ecdsa-jcs-2019"></a>.
               </li>
               <li>
 Set |cryptosuite|.|verifyProof| to the algorithm in Section
@@ -591,28 +569,11 @@ Set |cryptosuite|.|verifyProof| to the algorithm in Section
             </ol>
           </li>
           <li>
-If |options|.|type| is `DataIntegrityProof` and |options|.|cryptosuite| is
-`ecdsa-sd-2023` then:
+If |options|.|cryptosuite| is `ecdsa-sd-2023` then:
             <ol class="algorithm">
               <li>
-Set |cryptosuite|.|transform| to the algorithm in Section
-<a href="#base-proof-transformation-ecdsa-sd-2023"></a>.
-              </li>
-              <li>
-Set |cryptosuite|.|hash| to the algorithm in Section
-<a href="#base-proof-hashing-ecdsa-sd-2023"></a>.
-              </li>
-              <li>
-Set |cryptosuite|.|createProofConfig| to the algorithm in Section
-<a href="#base-proof-configuration-ecdsa-sd-2023"></a>.
-              </li>
-              <li>
-Set |cryptosuite|.|serializeProof| to the algorithm in Section
-<a href="#base-proof-serialization-ecdsa-sd-2023"></a>.
-              </li>
-              <li>
-Set |cryptosuite|.|deriveProof| to the algorithm in Section
-<a href="#add-derived-proof-ecdsa-sd-2023"></a>.
+Set |cryptosuite|.|createProof| to the algorithm in Section
+<a href="#create-base-proof-ecdsa-sd-2023"></a>.
               </li>
               <li>
 Set |cryptosuite|.|verifyProof| to the algorithm in Section
@@ -984,7 +945,7 @@ section also include the verification of such a data integrity proof.
         </p>
 
         <section>
-          <h4>Add Proof (ecdsa-jcs-2019)</h4>
+          <h4>Create Proof (ecdsa-jcs-2019)</h4>
 
           <p>
 To generate a proof, the algorithm in
@@ -2559,7 +2520,7 @@ section also include the verification of such a data integrity proof.
         </p>
 
         <section>
-          <h4>Add Base Proof (ecdsa-sd-2023)</h4>
+          <h4>Create Base Proof (ecdsa-sd-2023)</h4>
 
           <p>
 To generate a base proof, the algorithm in

--- a/index.html
+++ b/index.html
@@ -2924,11 +2924,14 @@ The following algorithm attempts verification of an `ecdsa-sd-2023` derived
 proof. This algorithm is called by a verifier of an ECDSA-SD-protected
 [=verifiable credential=]. The inputs include a JSON-LD document
 (<var>document</var>), an ECDSA-SD disclosure proof (<var>proof</var>), and any
-custom JSON-LD API options, such as a document loader. A single boolean
-<em>verification result</em> value is produced as output.
+custom JSON-LD API options, such as a document loader. This algorithm returns
+a [=verification result=]:
           </p>
 
           <ol class="algorithm">
+            <li>
+Let `unsecuredDocument` be a copy of `document` with the `proof` value removed.
+            </li>
             <li>
 Initialize `baseSignature`, `proofHash`, `publicKey`, `signatures`,
 `nonMandatory`, and `mandatoryHash` to the values associated with their property
@@ -2952,30 +2955,42 @@ Initialize `toVerify` to the result of calling the algorithm in Setion
 `mandatoryHash`.
             </li>
             <li>
-Initialize `verificationResult` be the result of applying the verification
+Initialize `verified` to true.
+            </li>
+            <li>
+Initialize `verificationCheck` be the result of applying the verification
 algorithm of the Elliptic Curve Digital Signature Algorithm (ECDSA) [FIPS-186-5],
 with `toVerify` as the data to be verified against the `baseSignature` using
-the public key specified by `publicKeyBytes`. If `verificationResult` is
-`false`, return `false`.
+the public key specified by `publicKeyBytes`. If `verificationCheck` is
+`false`, set `verified` to false.
             </li>
             <li>
 For every entry (`index`, `signature`) in `signatures`, verify every signature
 for every selectively disclosed (non-mandatory) statement:
               <ol class="algorithm">
                 <li>
-Initialize `verificationResult` to the result of applying the verification
+Initialize `verificationCheck` to the result of applying the verification
 algorithm Elliptic Curve Digital Signature Algorithm (ECDSA) [FIPS-186-5], with
 the UTF-8 representation of the value at `index` of `nonMandatory` as the data
 to be verified against `signature` using the public key specified by
 `publicKeyBytes`.
                 </li>
                 <li>
-If `verificationResult` is `false`, return `false`.
+If `verificationCheck` is `false`, set `verified` to false.
                 </li>
               </ol>
             </li>
             <li>
-Return `verificationResult` as <em>verification result</em>.
+Return a [=verification result=] with [=struct/items=]:
+              <dl data-link-for="verification result">
+                <dt>[=verified=]</dt>
+                <dd>The value of `verified`</dd>
+                <dt>[=verifiedDocument=]</dt>
+                <dd>
+`unsecuredDocument` if `verified` is `true`, otherwise <a
+data-cite="INFRA#nulls">Null</a>
+                </dd>
+              </dl>
             </li>
           </ol>
 

--- a/index.html
+++ b/index.html
@@ -608,17 +608,17 @@ or an error, is produced as output.
 
         <ol class="algorithm">
           <li>
-Let |proof| be an empty [=map=].
+Let |proof| be a clone of the proof options, |options|.
           </li>
           <li>
-Let |proof| be the result of running the algorithm in
+Let |proofConfig| be the result of running the algorithm in
 Section <a href="#proof-configuration-ecdsa-rdfc-2019"></a> with
 |options| passed as a parameter.
           </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
-href="#transformation-ecdsa-rdfc-2019"></a> with |unsecuredDocument| and
-|options| passed as parameters.
+href="#transformation-ecdsa-rdfc-2019"></a> with |unsecuredDocument|,
+|proofConfig|, and |options| passed as parameters.
           </li>
           <li>
 Let |hashData| be the result of running the algorithm in Section

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
           }
         },
         lint: {"no-unused-dfns": false},
-        xref: ["infra", "VC-DATA-MODEL-2.0"],
+        xref: ["INFRA", "VC-DATA-MODEL-2.0", "VC-DATA-INTEGRITY"],
         postProcess: [],
         otherLinks: [{
           key: "Related Specifications",
@@ -639,25 +639,119 @@ section also include the verification of such a data integrity proof.
         </p>
 
         <section>
-          <h4>Add Proof (ecdsa-rdfc-2019)</h4>
+          <h4>Create Proof (ecdsa-rdfc-2019)</h4>
 
-          <p>
-To generate a proof, the algorithm in
-<a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
-Section 4.1: Add Proof</a> in the Data Integrity
-[[VC-DATA-INTEGRITY]] specification MUST be executed.
-          </p>
+        <p>
+The following algorithm specifies how to create a [=data integrity proof=] given
+an <a>unsecured data document</a>. Required inputs are an
+<a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of
+proof options ([=map=] |options|). A [=data integrity proof=] ([=map=]),
+or an error, is produced as output.
+        </p>
+
+        <ol class="algorithm">
+          <li>
+Let |proof| be an empty [=map=].
+          </li>
+          <li>
+Let |proof| be the result of running the algorithm in
+Section <a href="#proof-configuration-ecdsa-rdfc-2019"></a> with
+|options| passed as a parameter.
+          </li>
+          <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#transformation-ecdsa-rdfc-2019"></a> with |unsecuredDocument| and
+|options| passed as parameters.
+          </li>
+          <li>
+Let |hashData| be the result of running the algorithm in Section
+<a href="#hashing-ecdsa-rdfc-2019"></a> with |transformedData| and |proofConfig|
+passed as a parameters.
+          </li>
+          <li>
+Let |proofBytes| be the result of running the algorithm in Section
+<a href="#proof-serialization-ecdsa-rdfc-2019"></a> with |hashData| and
+|options| passed as parameters.
+          </li>
+          <li>
+Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
+base58-btc-encoded Multibase value</a> of the |proofBytes|.
+          </li>
+          <li>
+Return |proof| as the [=data integrity proof=].
+          </li>
+        </ol>
+
         </section>
 
         <section>
           <h4>Verify Proof (ecdsa-rdfc-2019)</h4>
 
+
           <p>
-To verify a proof, the algorithm in
-<a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
-Section 4.2: Verify Proof</a> in the Data Integrity
-[[VC-DATA-INTEGRITY]] specification MUST be executed.
+The following algorithm specifies how to verify a [=data integrity proof=] given
+an <a>secured data document</a>. Required inputs are an
+<a>secured data document</a> ([=map=] |securedDocument|). This algorithm returns
+a <dfn>verification result</dfn>, which is a [=struct=] whose
+[=struct/items=] are:
           </p>
+          <dl>
+            <dt><dfn data-dfn-for="verification result">verified</dfn></dt>
+            <dd>`true` or `false`</dd>
+            <dt><dfn data-dfn-for="verification result">verifiedDocument</dfn></dt>
+            <dd>
+<a data-cite="INFRA#nulls">Null</a>, if [=verification result/verified=] is
+`false`; otherwise, an [=unsecured data document=]
+            </dd>
+          </dl>
+
+          <ol class="algorithm">
+          <li>
+Let |unsecuredDocument| be a copy of |securedDocument| with
+the `proof` value removed.
+          </li>
+          <li>
+Let |proofConfig| be a copy of |securedDocument|.|proof| with `proofValue`
+removed.
+          </li>
+          <li>
+Let |proofBytes| be the
+<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base58-btc
+value</a> in |securedDocument|.|proof|.|proofValue|.
+          </li>
+          <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#transformation-ecdsa-rdfc-2019"></a> with |unsecuredDocument| and
+|proofConfig| passed as parameters.
+          </li>
+          <li>
+Let |hashData| be the result of running the algorithm in Section
+<a href="#hashing-ecdsa-rdfc-2019"></a> with |transformedData| and |proofConfig|
+passed as a parameters.
+          </li>
+          <li>
+Let |verified:boolean| be the result of running the algorithm in Section
+<a href="#proof-verification-ecdsa-rdfc-2019"></a> algorithm on |hashData|,
+|proofBytes|, and |proofConfig|.
+            </li>
+            <li>
+If |proof|.|created| does not [=map/exist=],
+an error MUST be raised and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#MALFORMED_PROOF_ERROR">
+MALFORMED_PROOF_ERROR</a>.
+            </li>
+            <li>
+Return a [=verification result=] with [=struct/items=]:
+              <dl data-link-for="verification result">
+                <dt>[=verified=]</dt>
+                <dd>|verified|</dd>
+                <dt>[=verifiedDocument=]</dt>
+                <dd>
+|unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
+              </dl>
+            </li>
+          </ol>
+
         </section>
 
         <section>

--- a/index.html
+++ b/index.html
@@ -598,52 +598,51 @@ section also include the verification of such a data integrity proof.
         <section>
           <h4>Create Proof (ecdsa-rdfc-2019)</h4>
 
-        <p>
+          <p>
 The following algorithm specifies how to create a [=data integrity proof=] given
 an <a>unsecured data document</a>. Required inputs are an
-<a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of
-proof options ([=map=] |options|). A [=data integrity proof=] ([=map=]),
-or an error, is produced as output.
-        </p>
+<a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of proof
+options ([=map=] |options|). A [=data integrity proof=] ([=map=]), or an error,
+is produced as output.
+          </p>
 
-        <ol class="algorithm">
-          <li>
+          <ol class="algorithm">
+            <li>
 Let |proof| be a clone of the proof options, |options|.
-          </li>
-          <li>
+            </li>
+            <li>
 Let |proofConfig| be the result of running the algorithm in
 Section <a href="#proof-configuration-ecdsa-rdfc-2019"></a> with
 |options| passed as a parameter.
-          </li>
-          <li>
+            </li>
+            <li>
 Let |transformedData| be the result of running the algorithm in Section <a
 href="#transformation-ecdsa-rdfc-2019"></a> with |unsecuredDocument|,
 |proofConfig|, and |options| passed as parameters.
-          </li>
-          <li>
+            </li>
+            <li>
 Let |hashData| be the result of running the algorithm in Section
 <a href="#hashing-ecdsa-rdfc-2019"></a> with |transformedData| and |proofConfig|
 passed as a parameters.
-          </li>
-          <li>
+            </li>
+            <li>
 Let |proofBytes| be the result of running the algorithm in Section
 <a href="#proof-serialization-ecdsa-rdfc-2019"></a> with |hashData| and
 |options| passed as parameters.
-          </li>
-          <li>
+            </li>
+            <li>
 Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
 base58-btc-encoded Multibase value</a> of the |proofBytes|.
-          </li>
-          <li>
+            </li>
+            <li>
 Return |proof| as the [=data integrity proof=].
-          </li>
-        </ol>
+            </li>
+          </ol>
 
         </section>
 
         <section>
           <h4>Verify Proof (ecdsa-rdfc-2019)</h4>
-
 
           <p>
 The following algorithm specifies how to verify a [=data integrity proof=] given
@@ -943,12 +942,47 @@ section also include the verification of such a data integrity proof.
         <section>
           <h4>Create Proof (ecdsa-jcs-2019)</h4>
 
+
           <p>
-To generate a proof, the algorithm in
-<a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
-Section 4.1: Add Proof</a> of the Data Integrity
-[[VC-DATA-INTEGRITY]] specification MUST be executed.
+The following algorithm specifies how to create a [=data integrity proof=] given
+an <a>unsecured data document</a>. Required inputs are an
+<a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of proof
+options ([=map=] |options|). A [=data integrity proof=] ([=map=]), or an error,
+is produced as output.
           </p>
+
+          <ol class="algorithm">
+            <li>
+Let |proof| be a clone of the proof options, |options|.
+            </li>
+            <li>
+Let |proofConfig| be the result of running the algorithm in
+Section <a href="#proof-configuration-ecdsa-jcs-2019"></a> with
+|options| passed as a parameter.
+            </li>
+            <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#transformation-ecdsa-jcs-2019"></a> with |unsecuredDocument|,
+|proofConfig|, and |options| passed as parameters.
+            </li>
+            <li>
+Let |hashData| be the result of running the algorithm in Section
+<a href="#hashing-ecdsa-jcs-2019"></a> with |transformedData| and |proofConfig|
+passed as a parameters.
+            </li>
+            <li>
+Let |proofBytes| be the result of running the algorithm in Section
+<a href="#proof-serialization-ecdsa-jcs-2019"></a> with |hashData| and
+|options| passed as parameters.
+            </li>
+            <li>
+Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
+base58-btc-encoded Multibase value</a> of the |proofBytes|.
+            </li>
+            <li>
+Return |proof| as the [=data integrity proof=].
+            </li>
+          </ol>
         </section>
 
         <section>

--- a/index.html
+++ b/index.html
@@ -2552,12 +2552,47 @@ section also include the verification of such a data integrity proof.
         <section>
           <h4>Create Base Proof (ecdsa-sd-2023)</h4>
 
+
           <p>
-To generate a base proof, the algorithm in
-<a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
-Section 4.1: Add Proof</a> in the Data Integrity
-[[VC-DATA-INTEGRITY]] specification MUST be executed.
+The following algorithm specifies how to create a [=data integrity proof=] given
+an <a>unsecured data document</a>. Required inputs are an
+<a>unsecured data document</a> ([=map=] |unsecuredDocument|), and a set of proof
+options ([=map=] |options|). A [=data integrity proof=] ([=map=]), or an error,
+is produced as output.
           </p>
+
+          <ol class="algorithm">
+            <li>
+Let |proof| be a clone of the proof options, |options|.
+            </li>
+            <li>
+Let |proofConfig| be the result of running the algorithm in
+Section <a href="#base-proof-configuration-ecdsa-sd-2023"></a> with
+|options| passed as a parameter.
+            </li>
+            <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#base-proof-transformation-ecdsa-sd-2023"></a> with |unsecuredDocument|,
+|proofConfig|, and |options| passed as parameters.
+            </li>
+            <li>
+Let |hashData| be the result of running the algorithm in Section
+<a href="#base-proof-hashing-ecdsa-sd-2023"></a> with |transformedData| and |proofConfig|
+passed as a parameters.
+            </li>
+            <li>
+Let |proofBytes| be the result of running the algorithm in Section
+<a href="#base-proof-serialization-ecdsa-sd-2023"></a> with |hashData| and
+|options| passed as parameters.
+            </li>
+            <li>
+Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
+base64-url-encoded Multibase value</a> of the |proofBytes|.
+            </li>
+            <li>
+Return |proof| as the [=data integrity proof=].
+            </li>
+          </ol>
         </section>
 
         <section>

--- a/index.html
+++ b/index.html
@@ -140,6 +140,7 @@
           }
         },
         lint: {"no-unused-dfns": false},
+        xref: ["infra", "VC-DATA-MODEL-2.0"],
         postProcess: [],
         otherLinks: [{
           key: "Related Specifications",
@@ -522,6 +523,111 @@ by default, and abort processing upon detection.
       </p>
 
       <section>
+        <h3>Suite Selection Algorithm</h3>
+
+        <p>
+This algorithm is used to configure a cryptographic suite to be used by the
+<a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">Add Proof</a> and
+<a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">Verify Proof</a>
+functions in [[[VC-DATA-INTEGRITY]]]. The algorithm takes an options object
+([=map=] |options|) as input and returns a cryptosuite
+([=struct=] |cryptosuite|).
+        </p>
+
+        <ol class="algorithm">
+          <li>
+Initialize |cryptosuite| to an empty [=struct=].
+          </li>
+          <li>
+If |options|.|type| is `DataIntegrityProof` and |options|.|cryptosuite| is
+`ecdsa-rdfc-2019` then:
+            <ol class="algorithm">
+              <li>
+Set |cryptosuite|.|transform| to the algorithm in Section
+<a href="#transformation-ecdsa-rdfc-2019"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|hash| to the algorithm in Section
+<a href="#hashing-ecdsa-rdfc-2019"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|createProofConfig| to the algorithm in Section
+<a href="#proof-configuration-ecdsa-rdfc-2019"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|serializeProof| to the algorithm in Section
+<a href="#proof-serialization-ecdsa-rdfc-2019"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|verifyProof| to the algorithm in Section
+<a href="#proof-verification-ecdsa-rdfc-2019"></a>.
+              </li>
+            </ol>
+          </li>
+          <li>
+If |options|.|type| is `DataIntegrityProof` and |options|.|cryptosuite| is
+`ecdsa-jcs-2019` then:
+            <ol class="algorithm">
+              <li>
+Set |cryptosuite|.|transform| to the algorithm in Section
+<a href="#transformation-ecdsa-jcs-2019"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|hash| to the algorithm in Section
+<a href="#hashing-ecdsa-jcs-2019"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|createProofConfig| to the algorithm in Section
+<a href="#proof-configuration-ecdsa-jcs-2019"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|serializeProof| to the algorithm in Section
+<a href="#proof-serialization-ecdsa-jcs-2019"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|verifyProof| to the algorithm in Section
+<a href="#proof-verification-ecdsa-jcs-2019"></a>.
+              </li>
+            </ol>
+          </li>
+          <li>
+If |options|.|type| is `DataIntegrityProof` and |options|.|cryptosuite| is
+`ecdsa-sd-2023` then:
+            <ol class="algorithm">
+              <li>
+Set |cryptosuite|.|transform| to the algorithm in Section
+<a href="#base-proof-transformation-ecdsa-sd-2023"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|hash| to the algorithm in Section
+<a href="#base-proof-hashing-ecdsa-sd-2023"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|createProofConfig| to the algorithm in Section
+<a href="#base-proof-configuration-ecdsa-sd-2023"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|serializeProof| to the algorithm in Section
+<a href="#base-proof-serialization-ecdsa-sd-2023"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|deriveProof| to the algorithm in Section
+<a href="#add-derived-proof-ecdsa-sd-2023"></a>.
+              </li>
+              <li>
+Set |cryptosuite|.|verifyProof| to the algorithm in Section
+<a href="#verify-derived-proof-ecdsa-sd-2023"></a>.
+              </li>
+            </ol>
+          </li>
+          <li>
+Return |cryptosuite|.
+          </li>
+        </ol>
+
+      </section>
+
+      <section>
         <h3>ecdsa-rdfc-2019</h3>
 
         <p>
@@ -540,16 +646,6 @@ To generate a proof, the algorithm in
 <a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
 Section 4.1: Add Proof</a> in the Data Integrity
 [[VC-DATA-INTEGRITY]] specification MUST be executed.
-For that algorithm, the cryptographic suite specific
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
-transformation algorithm</a> is defined in Section
-<a href="#transformation-ecdsa-rdfc-2019"></a>, the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
-hashing algorithm</a> is defined in Section <a href="#hashing-ecdsa-rdfc-2019"></a>,
-and the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
-proof serialization algorithm</a> is defined in Section
-<a href="#proof-serialization-ecdsa-rdfc-2019"></a>.
           </p>
         </section>
 
@@ -561,16 +657,6 @@ To verify a proof, the algorithm in
 <a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
 Section 4.2: Verify Proof</a> in the Data Integrity
 [[VC-DATA-INTEGRITY]] specification MUST be executed.
-For that algorithm, the cryptographic suite specific
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
-transformation algorithm</a> is defined in Section
-<a href="#transformation-ecdsa-rdfc-2019"></a>, the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
-hashing algorithm</a> is defined in Section <a href="#hashing-ecdsa-rdfc-2019"></a>,
-and the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
-proof verification algorithm</a> is defined in Section
-<a href="#proof-verification-ecdsa-rdfc-2019"></a>.
           </p>
         </section>
 
@@ -811,16 +897,6 @@ To generate a proof, the algorithm in
 <a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
 Section 4.1: Add Proof</a> of the Data Integrity
 [[VC-DATA-INTEGRITY]] specification MUST be executed.
-For that algorithm, the cryptographic suite-specific
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
-transformation algorithm</a> is defined in Section
-<a href="#transformation-ecdsa-jcs-2019"></a>, the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
-hashing algorithm</a> is defined in Section <a href="#hashing-ecdsa-jcs-2019"></a>,
-and the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
-proof serialization algorithm</a> is defined in Section
-<a href="#proof-serialization-ecdsa-jcs-2019"></a>.
           </p>
         </section>
 
@@ -832,16 +908,6 @@ To verify a proof, the algorithm in
 <a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
 Section 4.2: Verify Proof</a> of the Data Integrity
 [[VC-DATA-INTEGRITY]] specification MUST be executed.
-For that algorithm, the cryptographic suite-specific
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
-transformation algorithm</a> is defined in Section
-<a href="#transformation-ecdsa-jcs-2019"></a>, the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
-hashing algorithm</a> is defined in Section <a href="#hashing-ecdsa-jcs-2019"></a>,
-and the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
-proof verification algorithm</a> is defined in Section
-<a href="#proof-verification-ecdsa-jcs-2019"></a>.
           </p>
         </section>
 
@@ -2406,16 +2472,6 @@ To generate a base proof, the algorithm in
 <a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
 Section 4.1: Add Proof</a> in the Data Integrity
 [[VC-DATA-INTEGRITY]] specification MUST be executed.
-For that algorithm, the cryptographic suite specific
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
-transformation algorithm</a> is defined in Section
-<a href="#base-proof-transformation-ecdsa-sd-2023"></a>, the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
-hashing algorithm</a> is defined in Section <a href="#base-proof-hashing-ecdsa-sd-2023"></a>,
-and the
-<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
-proof serialization algorithm</a> is defined in Section
-<a href="#base-proof-serialization-ecdsa-sd-2023"></a>.
           </p>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -989,11 +989,59 @@ Return |proof| as the [=data integrity proof=].
           <h4>Verify Proof (ecdsa-jcs-2019)</h4>
 
           <p>
-To verify a proof, the algorithm in
-<a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
-Section 4.2: Verify Proof</a> of the Data Integrity
-[[VC-DATA-INTEGRITY]] specification MUST be executed.
+The following algorithm specifies how to verify a [=data integrity proof=] given
+an <a>secured data document</a>. Required inputs are an
+<a>secured data document</a> ([=map=] |securedDocument|). This algorithm returns
+a [=verification result=]:
           </p>
+
+          <ol class="algorithm">
+          <li>
+Let |unsecuredDocument| be a copy of |securedDocument| with
+the `proof` value removed.
+          </li>
+          <li>
+Let |proofConfig| be a copy of |securedDocument|.|proof| with `proofValue`
+removed.
+          </li>
+          <li>
+Let |proofBytes| be the
+<a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base58-btc
+value</a> in |securedDocument|.|proof|.|proofValue|.
+          </li>
+          <li>
+Let |transformedData| be the result of running the algorithm in Section <a
+href="#transformation-ecdsa-jcs-2019"></a> with |unsecuredDocument| and
+|proofConfig| passed as parameters.
+          </li>
+          <li>
+Let |hashData| be the result of running the algorithm in Section
+<a href="#hashing-ecdsa-jcs-2019"></a> with |transformedData| and |proofConfig|
+passed as a parameters.
+          </li>
+          <li>
+Let |verified:boolean| be the result of running the algorithm in Section
+<a href="#proof-verification-ecdsa-jcs-2019"></a> algorithm on |hashData|,
+|proofBytes|, and |proofConfig|.
+            </li>
+            <li>
+If |proof|.|created| does not [=map/exist=],
+an error MUST be raised and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#MALFORMED_PROOF_ERROR">
+MALFORMED_PROOF_ERROR</a>.
+            </li>
+            <li>
+Return a [=verification result=] with [=struct/items=]:
+              <dl data-link-for="verification result">
+                <dt>[=verified=]</dt>
+                <dd>|verified|</dd>
+                <dt>[=verifiedDocument=]</dt>
+                <dd>
+|unsecuredDocument| if |verified| is `true`, otherwise <a data-cite="INFRA#nulls">Null</a></dd>
+              </dl>
+            </li>
+          </ol>
+
         </section>
 
         <section>

--- a/index.html
+++ b/index.html
@@ -103,7 +103,6 @@
         /*preProcess: [ webpayments.preProcess ],
         alternateFormats: [ {uri: "diff-20111214.html", label: "diff to previous version"} ],
         */
-        xref: ["INFRA", "VC-DATA-INTEGRITY", "VC-DATA-MODEL-2.0"],
         localBiblio: {
           MULTIBASE: {
             title: "Multibase",
@@ -139,9 +138,7 @@
             href: "https://doi.org/10.6028/NIST.SP.800-57pt1r5"
           }
         },
-        lint: {"no-unused-dfns": false},
         xref: ["INFRA", "VC-DATA-MODEL-2.0", "VC-DATA-INTEGRITY"],
-        postProcess: [],
         otherLinks: [{
           key: "Related Specifications",
           data: [{
@@ -530,8 +527,8 @@ This algorithm is used to configure a cryptographic suite to be used by the
 <a data-cite="VC-DATA-INTEGRITY#add-proof">Add Proof</a> and
 <a href="VC-DATA-INTEGRITY#verify-proof">Verify Proof</a>
 functions in [[[VC-DATA-INTEGRITY]]]. The algorithm takes an options object
-([=map=] |options|) as input and returns a [=cryptosuite instance=]
-([=struct=] |cryptosuite|).
+([=map=] |options|) as input and returns a [=data integrity cryptographic suite
+instance|cryptosuite instance=] ([=struct=] |cryptosuite|).
         </p>
 
         <ol class="algorithm">


### PR DESCRIPTION
This PR adds the "Cryptographic Suite Selection Algorithm" to the ECDSA Cryptosuite that was defined by @jyasskin in the Data Integrity specification [as an interface](https://w3c.github.io/vc-data-integrity/#dfn-suite-selection-algorithm) that MUST be defined by all DI cryptographic suite specifications. 

Additional alignments are needed in the Data Integrity spec to line all of this up (I'll link to that PR once that's done). There is some "misalignment" w/ the interface and the algorithms for deriving selective disclosure proofs that we might need to handle in a future PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/pull/57.html" title="Last updated on Feb 25, 2024, 8:38 PM UTC (3ad673c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/57/ac43f11...3ad673c.html" title="Last updated on Feb 25, 2024, 8:38 PM UTC (3ad673c)">Diff</a>