### PR TITLE
Cite reference on HMAC for HMAC key sizes and specify a normative size.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2673,8 +2673,8 @@ MUST use UTF-8 encoding.
 Initialize |hmac| to an HMAC API using a locally generated and exportable HMAC
 key. The HMAC uses the same hash algorithm used in the signature algorithm,
 which is detected via the |verificationMethod| provided to the
-function. i.e., SHA-256 for a P-256 curve. Per the recommendations of
-[[RFC2104]] the HMAC key MUST be the same length as the digest size. For SHA-256
+function, i.e., SHA-256 for a P-256 curve. Per the recommendations of
+[[RFC2104]], the HMAC key MUST be the same length as the digest size; for SHA-256,
 this is 256 bits or 32 bytes.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -2673,7 +2673,9 @@ MUST use UTF-8 encoding.
 Initialize |hmac| to an HMAC API using a locally generated and exportable HMAC
 key. The HMAC uses the same hash algorithm used in the signature algorithm,
 which is detected via the |verificationMethod| provided to the
-function. i.e., SHA-256 for a P-256 curve.
+function. i.e., SHA-256 for a P-256 curve. Per the recommendations of
+[[RFC2104]] the HMAC key MUST be the same length as the digest size. For SHA-256
+this is 256 bits or 32 bytes.
             </li>
             <li>
 Initialize |labelMapFactoryFunction| to the result of calling the


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-ecdsa/issues/58 by citing a reference on HMAC key size considerations and specifying a **normative** size for the HMAC key based on that reference.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/60.html" title="Last updated on Feb 29, 2024, 4:01 PM UTC (f7d7b67)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/60/0392e22...Wind4Greg:f7d7b67.html" title="Last updated on Feb 29, 2024, 4:01 PM UTC (f7d7b67)">Diff</a>