### PR TITLE
JCS Context Injection

### DIFF
--- a/index.html
+++ b/index.html
@@ -985,13 +985,23 @@ Return |proof| as the [=data integrity proof=].
 
         <section>
           <h4>Verify Proof (ecdsa-jcs-2019)</h4>
-
           <p>
 The following algorithm specifies how to verify a [=data integrity proof=] given
 an <a>secured data document</a>. Required inputs are an
 <a>secured data document</a> ([=map=] |securedDocument|). This algorithm returns
-a [=verification result=]:
+a [=verification result=], which is a [=struct=] whose
+[=struct/items=] are:
           </p>
+          <dl>
+            <dt>[=verification result/verified=]</dt>
+            <dd>`true` or `false`</dd>
+            <dt>[=verification result/verifiedDocument=]</dt>
+            <dd>
+<a data-cite="INFRA#nulls">Null</a>, if [=verification result/verified=] is
+`false`; otherwise, an [=unsecured data document=]
+            </dd>
+          </dl>
+
 
           <ol class="algorithm">
           <li>
@@ -1007,6 +1017,20 @@ Let |proofBytes| be the
 <a data-cite="VC-DATA-INTEGRITY#multibase-0">Multibase decoded base58-btc
 value</a> in |securedDocument|.|proof|.|proofValue|.
           </li>
+          <li>
+If |proofConfig|.<var>@context</var> exists:
+              <ol class="algorithm">
+                <li>
+Check that the |securedDocument|.<var>@context</var> starts with all values
+contained in the |proofConfig|.<var>@context</var> in the same order.
+Otherwise, set |verified| to `false` and skip to the last step.
+                </li>
+                <li>
+Set |unsecuredDocument|.<var>@context</var> equal to
+|proofConfig|.<var>@context</var>.
+                </li>
+              </ol>
+            </li>
           <li>
 Let |transformedData| be the result of running the algorithm in Section <a
 href="#transformation-ecdsa-jcs-2019"></a> with |unsecuredDocument| and

--- a/index.html
+++ b/index.html
@@ -937,8 +937,6 @@ section also include the verification of such a data integrity proof.
 
         <section>
           <h4>Create Proof (ecdsa-jcs-2019)</h4>
-
-
           <p>
 The following algorithm specifies how to create a [=data integrity proof=] given
 an <a>unsecured data document</a>. Required inputs are an
@@ -970,6 +968,10 @@ passed as a parameters.
 Let |proofBytes| be the result of running the algorithm in Section
 [[[#proof-serialization-ecdsa-jcs-2019]]] with |hashData| and
 |options| passed as parameters.
+            </li>
+            <li>
+Set <var>proof</var>.<var>@context</var> to
+<var>unsecuredDocument</var>.<var>@context</var>.
             </li>
             <li>
 Let |proof|.|proofValue| be a <a data-cite="VC-DATA-INTEGRITY#multibase-0">
@@ -1131,9 +1133,9 @@ The following algorithm specifies how to generate a
 <em>proof configuration</em> from a set of <em>proof options</em>
 that is used as input to the <a href="#hashing-ecdsa-jcs-2019">proof hashing algorithm</a>.
           </p>
-
           <p>
-The required inputs to this algorithm are <em>proof options</em>
+The required inputs to this algorithm are the <em>document</em>
+(|unsecuredDocument|) and the <em>proof options</em>
 (|options|). The <em>proof options</em> MUST contain a type identifier
 for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
@@ -1155,6 +1157,10 @@ If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
 If |proofConfig|.|created| is set and if the value is not a
 valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
 raised.
+            </li>
+            <li>
+Set <var>proofConfig</var>.<var>@context</var> to
+<var>unsecuredDocument</var>.<var>@context</var>
             </li>
             <li>
 Let |canonicalProofConfig| be the result of applying the

--- a/index.html
+++ b/index.html
@@ -947,6 +947,10 @@ is produced as output.
 
           <ol class="algorithm">
             <li>
+Set <var>options</var>.<var>@context</var> to
+<var>unsecuredDocument</var>.<var>@context</var>.
+            </li>
+            <li>
 Let |proof| be a clone of the proof options, |options|.
             </li>
             <li>
@@ -1181,10 +1185,6 @@ If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
 If |proofConfig|.|created| is set and if the value is not a
 valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
 raised.
-            </li>
-            <li>
-Set <var>proofConfig</var>.<var>@context</var> to
-<var>unsecuredDocument</var>.<var>@context</var>
             </li>
             <li>
 Let |canonicalProofConfig| be the result of applying the


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-data-integrity/issues/225 to properly handle `@context` injection issues that could arise with JCS. Note that this also applies to `@context` issues that could arise with proof sets/chains with JCS. This PR contains **normative** changes to the *Create Proof (ecdsa-jcs-2019)* and *Verify Proof (ecdsa-jcs-2019)* algorithms.

This PR does **NOT** include **informative** text such as:

1. Explanation of why these steps are necessary and sufficient. Such informative text is present in the discussions of issue  https://github.com/w3c/vc-data-integrity/issues/225 and could be extracted and included somewhere in the document. Thoughts?
2. Updates to the current *ecdsa-jcs-2019* test vectors in the specification. Will be updated after this PR is reviewed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/61.html" title="Last updated on May 31, 2024, 6:49 PM UTC (f06e930)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/61/b0ec946...Wind4Greg:f06e930.html" title="Last updated on May 31, 2024, 6:49 PM UTC (f06e930)">Diff</a>