### PR TITLE
Unify Error Handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -732,7 +732,7 @@ encoding.
             <li>
 If |options|.|type| is not set to the string
 `DataIntegrityProof` and |options|.|cryptosuite| is not
-set to the string `ecdsa-rdfc-2019` then
+set to the string `ecdsa-rdfc-2019`,
 an error MUST be raised and SHOULD convey an error type of
 `PROOF_TRANSFORMATION_ERROR`.
             </li>
@@ -1062,7 +1062,7 @@ encoding.
             <li>
 If |options|.|type| is not set to the string
 `DataIntegrityProof` and |options|.|cryptosuite| is not
-set to the string `ecdsa-jcs-2019`, then an error MUST be raised and SHOULD
+set to the string `ecdsa-jcs-2019`, an error MUST be raised and SHOULD
 convey an error type of `PROOF_TRANSFORMATION_ERROR`.
             </li>
             <li>
@@ -1156,7 +1156,7 @@ an error MUST be raised and SHOULD convey an error type of
             </li>
             <li>
 If |proofConfig|.|created| is set and if the value is not a
-valid [[XMLSCHEMA11-2]] datetime, an an error MUST be raised and SHOULD convey
+valid [[XMLSCHEMA11-2]] datetime, an error MUST be raised and SHOULD convey
 an error type of `PROOF_GENERATION_ERROR`.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -734,7 +734,7 @@ If |options|.|type| is not set to the string
 `DataIntegrityProof` and |options|.|cryptosuite| is not
 set to the string `ecdsa-rdfc-2019`,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_TRANSFORMATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_TRANSFORMATION_ERROR">PROOF_TRANSFORMATION_ERROR</a>.
             </li>
             <li>
 Let |canonicalDocument| be the result of applying the
@@ -824,12 +824,13 @@ Let |proofConfig| be a clone of the |options| object.
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
 |proofConfig|.|cryptosuite| is not set to `ecdsa-rdfc-2019`, an
 error MUST be raised and SHOULD convey an error type of
-`PROOF_GENERATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 If |proofConfig|.|created| is set and if the value is not a
 valid [[XMLSCHEMA11-2]] datetime, an error MUST be
-raised and SHOULD convey an error type of `PROOF_GENERATION_ERROR`.
+raised and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 Set |proofConfig|.|@context| to
@@ -1063,7 +1064,8 @@ encoding.
 If |options|.|type| is not set to the string
 `DataIntegrityProof` and |options|.|cryptosuite| is not
 set to the string `ecdsa-jcs-2019`, an error MUST be raised and SHOULD
-convey an error type of `PROOF_TRANSFORMATION_ERROR`.
+convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_TRANSFORMATION_ERROR">PROOF_TRANSFORMATION_ERROR</a>.
             </li>
             <li>
 Let |canonicalDocument| be the result of applying the
@@ -1152,12 +1154,13 @@ Let |proofConfig| be a clone of the |options| object.
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
 |proofConfig|.|cryptosuite| is not set to `ecdsa-jcs-2019`,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_GENERATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 If |proofConfig|.|created| is set and if the value is not a
 valid [[XMLSCHEMA11-2]] datetime, an error MUST be raised and SHOULD convey
-an error type of `PROOF_GENERATION_ERROR`.
+an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 Let |canonicalProofConfig| be the result of applying the
@@ -1783,7 +1786,7 @@ Set |parentValue| to |value|.
                 <li>
 Set |value| to |parentValue.|path|. If |value| is now undefined,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_GENERATION_ERROR`,
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>,
 indicating that the JSON pointer does not match the given |document|.
                 </li>
                 <li>
@@ -2204,7 +2207,8 @@ five elements, using the names `baseSignature`, `publicKey`, `hmacKey`,
             <li>
 If the |proofValue| string does not start with `u`, indicating that it is
 a multibase-base64url-no-pad-encoded value, an error MUST be raised
-and SHOULD convey an error type of `PROOF_VERIFICATION_ERROR`.
+and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
             </li>
             <li>
 Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
@@ -2213,7 +2217,8 @@ substring after the leading `u` in |proofValue|.
             <li>
 If the |decodedProofValue| does not start with the ECDSA-SD base proof
 header bytes `0xd9`, `0x5d`, and `0x00`, an error MUST be raised and SHOULD
-convey an error type of `PROOF_VERIFICATION_ERROR`.
+convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
             </li>
             <li>
 Initialize |components| to an array that is the result of CBOR-decoding the
@@ -2478,7 +2483,8 @@ contains a set to five elements, using the names "baseSignature", "publicKey",
 Ensure the |proofValue| string starts with `u`, indicating that it is a
 If the |proofValue| string does not start with `u`, indicating that it is a
 multibase-base64url-no-pad-encoded value, an error MUST be raised
-and SHOULD convey an error type of `PROOF_VERIFICATION_ERROR`.
+and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
             </li>
             <li>
 Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
@@ -2487,7 +2493,8 @@ substring after the leading `u` in |proofValue|.
             <li>
 If the |decodedProofValue| does not start with the ECDSA-SD disclosure proof
 header bytes `0xd9`, `0x5d`, and `0x01`, an error MUST be raised
-and SHOULD convey an error type of `PROOF_VERIFICATION_ERROR`.
+and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
             </li>
             <li>
 Initialize |components| to an array that is the result of CBOR-decoding the bytes
@@ -2495,7 +2502,8 @@ that follow the three-byte ECDSA-SD disclosure proof header. If the result is no
 an array of the following five elements — a byte array of length 64; a byte array
 of length 36; an array of byte arrays, each of length 64; a map of integers to
 byte arrays, each of length 32; and an array of integers — an error MUST be raised
-and SHOULD convey an error type of `PROOF_VERIFICATION_ERROR`.
+and SHOULD convey an error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
             </li>
             <li>
 Replace the fourth element in |components| using the result of calling the
@@ -2784,12 +2792,13 @@ Let |proofConfig| be a clone of the |options| object.
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
 |proofConfig|.|cryptosuite| is not set to `ecdsa-sd-2023`,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_GENERATION_ERROR`.
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 If |proofConfig|.|created| is set and if the value is not a
 valid [[XMLSCHEMA11-2]] datetime, an error MUST be raised and SHOULD convey an
-error type of `PROOF_GENERATION_ERROR`.
+error type of
+<a data-cite="VC-DATA-INTEGRITY#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
             </li>
             <li>
 Set |proofConfig|.|@context| to
@@ -2947,7 +2956,8 @@ custom JSON-LD API options, such as a document loader.
             <li>
 If the length of |signatures| does not match the length of |nonMandatory|,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_VERIFICATION_ERROR`, indicating that the signature count does not match
+<a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>,
+indicating that the signature count does not match
 the non-mandatory message count.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -1783,7 +1783,7 @@ Set |parentValue| to |value|.
                 <li>
 Set |value| to |parentValue.|path|. If |value| is now undefined,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_GENERATION_ERROR`
+`PROOF_GENERATION_ERROR`,
 indicating that the JSON pointer does not match the given |document|.
                 </li>
                 <li>
@@ -2202,8 +2202,8 @@ five elements, using the names `baseSignature`, `publicKey`, `hmacKey`,
 
           <ol class="algorithm">
             <li>
-Ensure the |proofValue| string starts with `u`, indicating that it is a
-multibase-base64url-no-pad-encoded value, if it does not an error MUST be raised
+If the |proofValue| string does not start with `u`, indicating that it is
+a multibase-base64url-no-pad-encoded value, an error MUST be raised
 and SHOULD convey an error type of `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
@@ -2211,8 +2211,8 @@ Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
 substring after the leading `u` in |proofValue|.
             </li>
             <li>
-Ensure that the |decodedProofValue| starts with the ECDSA-SD base proof header
-bytes 0xd9, 0x5d, and 0x00, if it does not an error MUST be raised and SHOULD
+If the |decodedProofValue| does not start with the ECDSA-SD base proof
+header bytes `0xd9`, `0x5d`, and `0x00`, an error MUST be raised and SHOULD
 convey an error type of `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
@@ -2476,7 +2476,8 @@ contains a set to five elements, using the names "baseSignature", "publicKey",
           <ol class="algorithm">
             <li>
 Ensure the |proofValue| string starts with `u`, indicating that it is a
-multibase-base64url-no-pad-encoded value, if it does not an error MUST be raised
+If the |proofValue| string does not start with `u`, indicating that it is a
+multibase-base64url-no-pad-encoded value, an error MUST be raised
 and SHOULD convey an error type of `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
@@ -2484,18 +2485,17 @@ Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
 substring after the leading `u` in |proofValue|.
             </li>
             <li>
-Ensure that the |decodedProofValue| starts with the ECDSA-SD disclosure proof
-header bytes `0xd9`, `0x5d`, and `0x01`, if it does not an error MUST be raised
+If the |decodedProofValue| does not start with the ECDSA-SD disclosure proof
+header bytes `0xd9`, `0x5d`, and `0x01`, an error MUST be raised
 and SHOULD convey an error type of `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
-Initialize |components| to an array that is the result of CBOR-decoding the
-bytes that follow the three-byte ECDSA-SD disclosure proof header. Ensure the
-result is an array of five elements. Ensure the result is an array of five
-elements: a byte array of length 64, a byte array of length 36, an array of byte
-arrays, each of length 64, a map of integers to byte arrays of length 32, and an
-array of integers, if it does not an error MUST be raised and SHOULD convey an
-error type of `PROOF_VERIFICATION_ERROR`.
+Initialize |components| to an array that is the result of CBOR-decoding the bytes
+that follow the three-byte ECDSA-SD disclosure proof header. If the result is not
+an array of the following five elements — a byte array of length 64; a byte array
+of length 36; an array of byte arrays, each of length 64; a map of integers to
+byte arrays, each of length 32; and an array of integers — an error MUST be raised
+and SHOULD convey an error type of `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
 Replace the fourth element in |components| using the result of calling the
@@ -2947,7 +2947,7 @@ custom JSON-LD API options, such as a document loader.
             <li>
 If the length of |signatures| does not match the length of |nonMandatory|,
 an error MUST be raised and SHOULD convey an error type of
-`PROOF_VERIFICATION_ERROR` indicating that the signature count does not match
+`PROOF_VERIFICATION_ERROR`, indicating that the signature count does not match
 the non-mandatory message count.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -822,12 +822,13 @@ Let |proofConfig| be a clone of the |options| object.
             <li>
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
 |proofConfig|.|cryptosuite| is not set to `ecdsa-rdfc-2019`, an
-`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+error MUST be raised and SHOULD convey an error type of
+`PROOF_GENERATION_ERROR`.
             </li>
             <li>
 If |proofConfig|.|created| is set and if the value is not a
-valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
-raised.
+valid [[XMLSCHEMA11-2]] datetime, an error MUST be
+raised and SHOULD convey an error type of `PROOF_GENERATION_ERROR`.
             </li>
             <li>
 Set |proofConfig|.|@context| to
@@ -1149,11 +1150,11 @@ Let |proofConfig| be a clone of the |options| object.
             <li>
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
 |proofConfig|.|cryptosuite| is not set to `ecdsa-jcs-2019`, an
-`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+`PROOF_GENERATION_ERROR` error MUST be raised.
             </li>
             <li>
 If |proofConfig|.|created| is set and if the value is not a
-valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
+valid [[XMLSCHEMA11-2]] datetime, an `PROOF_GENERATION_ERROR` error MUST be
 raised.
             </li>
             <li>
@@ -2773,11 +2774,11 @@ Let |proofConfig| be a clone of the |options| object.
             <li>
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
 |proofConfig|.|cryptosuite| is not set to `ecdsa-sd-2023`, an
-`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+`PROOF_GENERATION_ERROR` error MUST be raised.
             </li>
             <li>
 If |proofConfig|.|created| is set and if the value is not a
-valid [[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be
+valid [[XMLSCHEMA11-2]] datetime, an `PROOF_GENERATION_ERROR` error MUST be
 raised.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -732,8 +732,9 @@ encoding.
             <li>
 If |options|.|type| is not set to the string
 `DataIntegrityProof` and |options|.|cryptosuite| is not
-set to the string `ecdsa-rdfc-2019` then a `PROOF_TRANSFORMATION_ERROR` MUST be
-raised.
+set to the string `ecdsa-rdfc-2019` then
+an error MUST be raised and SHOULD convey an error type of
+`PROOF_TRANSFORMATION_ERROR`.
             </li>
             <li>
 Let |canonicalDocument| be the result of applying the
@@ -1061,8 +1062,8 @@ encoding.
             <li>
 If |options|.|type| is not set to the string
 `DataIntegrityProof` and |options|.|cryptosuite| is not
-set to the string `ecdsa-jcs-2019`, then a `PROOF_TRANSFORMATION_ERROR` MUST be
-raised.
+set to the string `ecdsa-jcs-2019`, then an error MUST be raised and SHOULD
+convey an error type of `PROOF_TRANSFORMATION_ERROR`.
             </li>
             <li>
 Let |canonicalDocument| be the result of applying the
@@ -1149,13 +1150,14 @@ Let |proofConfig| be a clone of the |options| object.
             </li>
             <li>
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
-|proofConfig|.|cryptosuite| is not set to `ecdsa-jcs-2019`, an
-`PROOF_GENERATION_ERROR` error MUST be raised.
+|proofConfig|.|cryptosuite| is not set to `ecdsa-jcs-2019`,
+an error MUST be raised and SHOULD convey an error type of
+`PROOF_GENERATION_ERROR`.
             </li>
             <li>
 If |proofConfig|.|created| is set and if the value is not a
-valid [[XMLSCHEMA11-2]] datetime, an `PROOF_GENERATION_ERROR` error MUST be
-raised.
+valid [[XMLSCHEMA11-2]] datetime, an an error MUST be raised and SHOULD convey
+an error type of `PROOF_GENERATION_ERROR`.
             </li>
             <li>
 Let |canonicalProofConfig| be the result of applying the
@@ -1779,7 +1781,9 @@ Set |selectedParent| to |selectedValue|.
 Set |parentValue| to |value|.
                 </li>
                 <li>
-Set |value| to |parentValue.|path|. If |value| is now undefined, throw an error
+Set |value| to |parentValue.|path|. If |value| is now undefined,
+an error MUST be raised and SHOULD convey an error type of
+`PROOF_GENERATION_ERROR`
 indicating that the JSON pointer does not match the given |document|.
                 </li>
                 <li>
@@ -2199,7 +2203,8 @@ five elements, using the names `baseSignature`, `publicKey`, `hmacKey`,
           <ol class="algorithm">
             <li>
 Ensure the |proofValue| string starts with `u`, indicating that it is a
-multibase-base64url-no-pad-encoded value, throwing an error if it does not.
+multibase-base64url-no-pad-encoded value, if it does not an error MUST be raised
+and SHOULD convey an error type of `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
 Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
@@ -2207,7 +2212,8 @@ substring after the leading `u` in |proofValue|.
             </li>
             <li>
 Ensure that the |decodedProofValue| starts with the ECDSA-SD base proof header
-bytes 0xd9, 0x5d, and 0x00, throwing an error if it does not.
+bytes 0xd9, 0x5d, and 0x00, if it does not an error MUST be raised and SHOULD
+convey an error type of `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
 Initialize |components| to an array that is the result of CBOR-decoding the
@@ -2470,7 +2476,8 @@ contains a set to five elements, using the names "baseSignature", "publicKey",
           <ol class="algorithm">
             <li>
 Ensure the |proofValue| string starts with `u`, indicating that it is a
-multibase-base64url-no-pad-encoded value, throwing an error if it does not.
+multibase-base64url-no-pad-encoded value, if it does not an error MUST be raised
+and SHOULD convey an error type of `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
 Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
@@ -2478,7 +2485,8 @@ substring after the leading `u` in |proofValue|.
             </li>
             <li>
 Ensure that the |decodedProofValue| starts with the ECDSA-SD disclosure proof
-header bytes `0xd9`, `0x5d`, and `0x01`, throwing an error if it does not.
+header bytes `0xd9`, `0x5d`, and `0x01`, if it does not an error MUST be raised
+and SHOULD convey an error type of `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
 Initialize |components| to an array that is the result of CBOR-decoding the
@@ -2486,7 +2494,8 @@ bytes that follow the three-byte ECDSA-SD disclosure proof header. Ensure the
 result is an array of five elements. Ensure the result is an array of five
 elements: a byte array of length 64, a byte array of length 36, an array of byte
 arrays, each of length 64, a map of integers to byte arrays of length 32, and an
-array of integers, throwing an error if not.
+array of integers, if it does not an error MUST be raised and SHOULD convey an
+error type of `PROOF_VERIFICATION_ERROR`.
             </li>
             <li>
 Replace the fourth element in |components| using the result of calling the
@@ -2773,13 +2782,14 @@ Let |proofConfig| be a clone of the |options| object.
             </li>
             <li>
 If |proofConfig|.|type| is not set to `DataIntegrityProof` and/or
-|proofConfig|.|cryptosuite| is not set to `ecdsa-sd-2023`, an
-`PROOF_GENERATION_ERROR` error MUST be raised.
+|proofConfig|.|cryptosuite| is not set to `ecdsa-sd-2023`,
+an error MUST be raised and SHOULD convey an error type of
+`PROOF_GENERATION_ERROR`.
             </li>
             <li>
 If |proofConfig|.|created| is set and if the value is not a
-valid [[XMLSCHEMA11-2]] datetime, an `PROOF_GENERATION_ERROR` error MUST be
-raised.
+valid [[XMLSCHEMA11-2]] datetime, an error MUST be raised and SHOULD convey an
+error type of `PROOF_GENERATION_ERROR`.
             </li>
             <li>
 Set |proofConfig|.|@context| to
@@ -2935,9 +2945,10 @@ names in the object returned when calling the algorithm in Section
 custom JSON-LD API options, such as a document loader.
             </li>
             <li>
-If the length of |signatures| does not match the length of |nonMandatory|, throw
-an error indicating that the signature count does not match the non-mandatory
-message count.
+If the length of |signatures| does not match the length of |nonMandatory|,
+an error MUST be raised and SHOULD convey an error type of
+`PROOF_VERIFICATION_ERROR` indicating that the signature count does not match
+the non-mandatory message count.
             </li>
             <li>
 Initialize |publicKeyBytes| to the public key bytes expressed in |publicKey|.


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-di-ecdsa/issues/63. It unifies error codes, error handling language, and adds error codes where needed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/64.html" title="Last updated on Jun 28, 2024, 7:09 PM UTC (671150e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/64/b0ec946...Wind4Greg:671150e.html" title="Last updated on Jun 28, 2024, 7:09 PM UTC (671150e)">Diff</a>