### PR TITLE
corrections missed in #64

### DIFF
--- a/index.html
+++ b/index.html
@@ -2249,7 +2249,7 @@ convey an error type of
             </li>
             <li>
 Initialize |components| to an array that is the result of CBOR-decoding the
-bytes that follow the three-byte ECDSA-SD base proof header. Ensure the result
+bytes that follow the three-byte ECDSA-SD base proof header. Confirm that the result
 is an array of five elements.
             </li>
             <li>
@@ -2507,7 +2507,6 @@ contains a set to five elements, using the names "baseSignature", "publicKey",
 
           <ol class="algorithm">
             <li>
-Ensure the |proofValue| string starts with `u`, indicating that it is a
 If the |proofValue| string does not start with `u`, indicating that it is a
 multibase-base64url-no-pad-encoded value, an error MUST be raised
 and SHOULD convey an error type of


### PR DESCRIPTION
- delete now-errant line

- fix "ensure" phrasing — note: this sentence may need further work, as it's not clear whether confirming `an array of five elements` is sufficient to ensure proper population of `the five [named] elements` -- 
  ```
  Initialize |components| to an array that is the result of CBOR-decoding the
  bytes that follow the three-byte ECDSA-SD base proof header. Ensure the result
  is an array of five elements.
              </li>
              <li>
  Return an object with properties set to the five elements, using the names
  `baseSignature`, `publicKey`, `hmacKey`, `signatures`, and `mandatoryPointers`,
  respectively.
  ```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/pull/65.html" title="Last updated on Jul 1, 2024, 3:17 PM UTC (3548c10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/65/5daa501...3548c10.html" title="Last updated on Jul 1, 2024, 3:17 PM UTC (3548c10)">Diff</a>