### PR TITLE
(Editorial) Expanded on the note on algorithm names

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,8 +228,8 @@ algorithm which is also specified in [[RFC6979]].
       </p>
 
       <p class="note">
-The elliptic curves P-256 and P-384 of [[NIST-SP-800-186]] are referred to as
-<em>secp256r1</em> and <em>secp384r1</em> respectively in [[SECG2]]. This notation 
+The elliptic curves P-256 and P-384 of [[NIST-SP-800-186]] are respectively referred
+to as <em>secp256r1</em> and <em>secp384r1</em> in [[SECG2]]. This notation 
 is sometimes used in ECDSA software libraries. Developers 
 must be careful not to confuse <em>secp256<b>r</b>1</em> terms with 
 <em>secp256<b>k</b>1</em>: the second is a <em>different</em> elliptic curve that is not

--- a/index.html
+++ b/index.html
@@ -226,6 +226,17 @@ specified in [[FIPS-186-5]] with elliptic curves P-256 and P-384 specified in
 [[NIST-SP-800-186]]. [[FIPS-186-5]] includes the <em>deterministic</em> ECDSA
 algorithm which is also specified in [[RFC6979]].
       </p>
+
+      <p class="note">
+The elliptic curves P-256 and P-384 of [[NIST-SP-800-186]] are referred to as
+<em>secp256r1</em> and <em>secp384r1</em> respectively in [[SECG2]]. This notation 
+is sometimes used in ECDSA software libraries. Developers 
+must be careful not to confuse <em>secp256<b>r</b>1</em> terms with 
+<em>secp256<b>k</b>1</em>: the second is a <em>different</em> elliptic curve that is not
+used by this specification. ECDSA software libraries may implement only one of the two 
+alternatives.
+      </p>
+
       <p>
 This specification uses either the RDF Dataset Canonicalization Algorithm
 [[RDF-CANON]] or the JSON Canonicalization Scheme [[RFC8785]] to transform the
@@ -233,11 +244,6 @@ input document into its canonical form. It uses one of two mechanisms to digest
 and sign: SHA-256 [[RFC6234]] as the message digest algorithm and ECDSA with
 Curve P-256 as the signature algorithm, or SHA-384 [[RFC6234]] as the message
 digest algorithm and ECDSA with Curve P-384 as the signature algorithm.
-      </p>
-      <p class="note">
-The elliptic curves P-256 and P-384 of [[NIST-SP-800-186]] are referred to as
-<em>secp256r1</em> and <em>secp384r1</em> respectively in [[SECG2]]. In
-addition, this notation is sometimes used in ECDSA software libraries.
       </p>
 
       <section id="terminology">

--- a/index.html
+++ b/index.html
@@ -227,15 +227,20 @@ specified in [[FIPS-186-5]] with elliptic curves P-256 and P-384 specified in
 algorithm which is also specified in [[RFC6979]].
       </p>
 
-      <p class="note">
+      <div class="note">
+        <p>
 The elliptic curves P-256 and P-384 of [[NIST-SP-800-186]] are respectively referred
-to as <em>secp256r1</em> and <em>secp384r1</em> in [[SECG2]]. This notation 
-is sometimes used in ECDSA software libraries. Developers 
-must be careful not to confuse <em>secp256<b>r</b>1</em> terms with 
-<em>secp256<b>k</b>1</em>: the second is a <em>different</em> elliptic curve that is not
-used by this specification. ECDSA software libraries may implement only one of the two 
-alternatives.
-      </p>
+to as <em>secp256r1</em> and <em>secp384r1</em> in [[SECG2]]. This notation is
+sometimes also used by ECDSA software libraries.
+        </p>
+        <p>
+Developers are cautioned to not confuse <em>secp256<b>r</b>1</em> terms with
+<em>secp256<b>k</b>1</em> terms; the latter are from a third, <em>different</em>,
+elliptic curve, that is not used by this specification. ECDSA software libraries
+might not implement all of these curves, so developers need to take care when
+choosing an ECDSA software library for their implementation.
+        </p>
+      </div>
 
       <p>
 This specification uses either the RDF Dataset Canonicalization Algorithm


### PR DESCRIPTION
This proposed change is based on implementation experience: the difference between `secp256r1` and `secp256k1` is not alway appearent for application developers (who are not seasoned crypto developers). This change tries to help a bit.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/pull/68.html" title="Last updated on Aug 14, 2024, 6:28 AM UTC (5876621)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/68/2a8e5fd...5876621.html" title="Last updated on Aug 14, 2024, 6:28 AM UTC (5876621)">Diff</a>