### PR TITLE
Changed the reference to canonical forms of rdf-canon

### DIFF
--- a/index.html
+++ b/index.html
@@ -758,7 +758,7 @@ and then <a data-cite="JSON-LD11-API#deserialize-json-ld-to-rdf-algorithm">
 to RDF statements</a>, applying the <a data-cite="RDF-CANON#canon-algorithm">RDF Dataset Canonicalization
 Algorithm</a> [[RDF-CANON]] to the result, and then serializing the result to a
 <a data-cite="RDF-CANON#dfn-serialized-canonical-form">serialized canonical form</a> [[RDF-CANON]].
-For canonicalization one must use the hash algorithm appropriate in security level to
+For canonicalization, one is expected to use a hash algorithm that has an appropriate security level for
 the curve used; see <a href="#canon-and-hash">further details</a>.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -520,7 +520,7 @@ functions in this section use information from the verification method
 &mdash; such as the cryptographic hashing algorithm.
       </p>
 
-      <p>
+      <p id="canon-and-hash">
 When the RDF Dataset Canonicalization Algorithm (RDFC-1.0) [[RDF-CANON]] is used
 with ECDSA algorithms, the cryptographic hashing function used by RDFC-1.0 is
 chosen based on the size of the associated public key. For P-256 keys, the
@@ -755,9 +755,11 @@ an error MUST be raised and SHOULD convey an error type of
 Let |canonicalDocument| be the result of converting |unsecuredDocument| to
 <a data-cite="JSON-LD11-API#expansion-algorithm">JSON-LD expanded form</a>
 and then <a data-cite="JSON-LD11-API#deserialize-json-ld-to-rdf-algorithm">
-to RDF statements</a>, applying the <a data-cite="RDF-CANON#canon-algorithm">
-RDF Dataset Canonicalization Algorithm</a>, and then serializing the
-result to [[N-QUADS]].
+to RDF statements</a>, applying the <a data-cite="RDF-CANON#canon-algorithm">RDF Dataset Canonicalization
+Algorithm</a> [[RDF-CANON]] to the result, and then serializing the result to a
+<a data-cite="RDF-CANON#dfn-serialized-canonical-form">serialized canonical form</a> [[RDF-CANON]].
+For canonicalization one must use the hash algorithm appropriate in security level to
+the curve used; see <a href="#canon-and-hash">further details</a>.
             </li>
             <li>
 Return |canonicalDocument| as the <em>transformed data document</em>.
@@ -1316,7 +1318,7 @@ cryptographic suites that perform selective disclosure.
           <h4>labelReplacementCanonicalizeNQuads</h4>
 
           <p>
-The following algorithm canonicalizes an array of N-Quad strings and replaces
+The following algorithm canonicalizes an array of N-Quad [[N-QUADS]] strings and replaces
 any blank node identifiers in the canonicalized result using a label map
 factory function, |labelMapFactoryFunction|. The required inputs are
 an array of N-Quad strings (|nquads|), and a label map factory function


### PR DESCRIPTION
This PR covers two issues: https://github.com/w3c/vc-di-ecdsa/pull/75 and https://github.com/w3c/vc-di-ecdsa/issues/74. The changes for the former are identical to the eddsa case in https://github.com/w3c/vc-di-eddsa/pull/98 (already merged). 

I did one PR for two issues because they affect the same paragraph, and a separate handling of these would inevitably lead to merge conflicts...

Note also that I have added a separate `[[N-QUADS]]` to the next occurrence of the term to ensure a proper item in the reference list.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/pull/77.html" title="Last updated on Sep 17, 2024, 6:12 AM UTC (fdde770)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/77/13830e1...fdde770.html" title="Last updated on Sep 17, 2024, 6:12 AM UTC (fdde770)">Diff</a>