### PR TITLE
Add language to clarify how to consistently set the urnScheme parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -1630,14 +1630,16 @@ Return |skolemizedExpandedDocument|.
 The following algorithm replaces all blank node identifiers in a compact
 JSON-LD document with custom-scheme URNs. The required inputs are a compact
 JSON-LD document (|document|) and a custom URN scheme
-(|urnScheme|). The |document| is assumed to use only one
+(|urnScheme|) which defaults to "custom-scheme:". The |document| is assumed to
+use only one
 <em>@context</em> property at the top level of the document. Any additional
 custom options (such as a document loader) can also be passed. It produces both
 an expanded form of the skolemized JSON-LD document
 (|skolemizedExpandedDocument| and a compact form of the skolemized
 JSON-LD document (|skolemizedCompactDocument|) as output. The
 skolemization used in this operation is intended to be reversible through the
-use of the algorithm in Section [[[#todeskolemizednquads]]].
+use of the algorithm in Section [[[#todeskolemizednquads]]] which must use the
+same custom URN scheme (|urnScheme|).
           </p>
 
           <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -1638,7 +1638,7 @@ an expanded form of the skolemized JSON-LD document
 (|skolemizedExpandedDocument| and a compact form of the skolemized
 JSON-LD document (|skolemizedCompactDocument|) as output. The
 skolemization used in this operation is intended to be reversible through the
-use of the algorithm in Section [[[#todeskolemizednquads]]] which must use the
+use of the algorithm in Section [[[#todeskolemizednquads]]] which uses the
 same custom URN scheme (|urnScheme|).
           </p>
 


### PR DESCRIPTION
This PR attempts to address issue https://github.com/w3c/vc-di-ecdsa/issues/80. The essence is that this parameter needs to be set the same in section 3.4.8 skolemizeCompactJsonLd as well as in section 3.4.9 toDeskolemizedNQuads. Word smith this as you see appropriate.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/81.html" title="Last updated on Nov 17, 2024, 7:15 PM UTC (1eb28d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/81/48008b2...Wind4Greg:1eb28d5.html" title="Last updated on Nov 17, 2024, 7:15 PM UTC (1eb28d5)">Diff</a>