### PR TITLE
Fix missing input in Base Proof Configuration (ecdsa-sd-2023) procedure

### DIFF
--- a/index.html
+++ b/index.html
@@ -2800,7 +2800,10 @@ that is used as input to the
 
           <p>
 The required inputs to this algorithm are <em>proof options</em>
-(|options|). The <em>proof options</em> MUST contain a type identifier
+(|options|) and the
+<a data-cite="vc-data-integrity#dfn-unsecured-data-document">unsecured data
+document</a> (|unsecuredDocument|).
+The <em>proof options</em> MUST contain a type identifier
 for the
 <a data-cite="vc-data-integrity#dfn-cryptosuite">
 cryptographic suite</a> (|type|) and MUST contain a cryptosuite


### PR DESCRIPTION
This PR fixes a missing input in the introduction to the *Base Proof Configuration (ecdsa-sd-2023)* procedure.  The input is used in the procedure but not mentioned at the beginning of the procedure. This is similar to issue https://github.com/w3c/vc-di-bbs/issues/189.