### PR TITLE
Fix path to test vector file. Fix spelling errors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3431,10 +3431,10 @@ Signing begins with a credential without an attached proof, which is converted
 to canonical form, and then hashed, as shown in the following three examples.
         </p>
 
-        <pre class="example nohighlight" title="Employment Autorization Credential without Proof" data-include="TestVectors/employmentAuth.json"
+        <pre class="example nohighlight" title="Employment Authorization Credential without Proof" data-include="TestVectors/employmentAuth.json"
         data-include-format="text"></pre>
 
-        <pre class="example nohighlight" title="Canonical Employment Autorization Credential without Proof" data-include="TestVectors/employ/ecdsa-rdfc-2019-p384/canonDocECDSAP384.txt"
+        <pre class="example nohighlight" title="Canonical Employment Authorization Credential without Proof" data-include="TestVectors/ecdsa-rdfc-2019-p384/employ/canonDocECDSAP384.txt"
         data-include-format="text"></pre>
 
 
@@ -3481,7 +3481,7 @@ option document.
           </li>
         </ol>
 
-        <pre class="example nohighlight" title="Signed Employment Autorization Credential"
+        <pre class="example nohighlight" title="Signed Employment Authorization Credential"
         data-include="TestVectors/ecdsa-rdfc-2019-p384/employ/signedECDSAP384.json" data-include-format="text"></pre>
       </section>
 


### PR DESCRIPTION
This PR fixes an error in a non-normative test vector path that was causing the information to not appear correctly in the specification. In addition a couple of spelling errors in the non-normative text were corrected.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/93.html" title="Last updated on Jan 21, 2025, 4:55 PM UTC (c41274a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/93/67bfafe...Wind4Greg:c41274a.html" title="Last updated on Jan 21, 2025, 4:55 PM UTC (c41274a)">Diff</a>