### PR TITLE
Fix Cross Links to Function Definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -2322,8 +2322,8 @@ Increment |index|.
               </ol>
             </li>
             <li>
-Initialize |revealDocument| to the result of the "selectJsonLd"
-algorithm, passing |document|, and |combinedPointers| as |pointers|.
+Initialize |revealDocument| to the result of the algorithm in Section
+[[[#selectjsonld]]], passing |document|, and |combinedPointers| as |pointers|.
             </li>
             <li>
 Run the RDF Dataset Canonicalization Algorithm [[RDF-CANON]] on

--- a/index.html
+++ b/index.html
@@ -2250,8 +2250,8 @@ Initialize |hmac| to an HMAC API using |hmacKey|. The HMAC uses the same hash
 algorithm used in the signature algorithm, i.e., SHA-256 for a P-256 curve.
             </li>
             <li>
-Initialize |labelMapFactoryFunction| to the result of calling the
-|createHmacIdLabelMapFunction| algorithm passing |hmac|.
+Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
+section [[[#createhmacidlabelmapfunction]]] passing |hmac|.
             </li>
             <li>
 Initialize |combinedPointers| to the concatenation of |mandatoryPointers|
@@ -2669,8 +2669,8 @@ function, i.e., SHA-256 for a P-256 curve. Per the recommendations of
 this is 256 bits or 32 bytes.
             </li>
             <li>
-Initialize |labelMapFactoryFunction| to the result of calling the
-|createHmacIdLabelMapFunction| algorithm passing |hmac|.
+Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
+Section [[[#createhmacidlabelmapfunction]]] passing |hmac|.
             </li>
             <li>
 Initialize |groupDefinitions| to a map with an entry with a key of the string

--- a/index.html
+++ b/index.html
@@ -2536,8 +2536,8 @@ object returned when calling the algorithm in Section
 [[[#parsederivedproofvalue]]], passing |proofValue| from |proof|.
             </li>
             <li>
-Initialize |labelMapFactoryFunction| to the result of calling the
-"createLabelMapFunction" algorithm.
+Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
+Section [[[#createlabelmapfunction]]].
             </li>
             <li>
 Initialize |nquads| to the result of calling the "labelReplacementCanonicalize"

--- a/index.html
+++ b/index.html
@@ -2251,7 +2251,7 @@ algorithm used in the signature algorithm, i.e., SHA-256 for a P-256 curve.
             </li>
             <li>
 Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
-section [[[#createhmacidlabelmapfunction]]] passing |hmac|.
+section [[[#createhmacidlabelmapfunction]]], passing |hmac|.
             </li>
             <li>
 Initialize |combinedPointers| to the concatenation of |mandatoryPointers|
@@ -2322,7 +2322,7 @@ Increment |index|.
               </ol>
             </li>
             <li>
-Initialize |revealDocument| to the result of the algorithm in Section
+Initialize |revealDocument| to the result of the calling the algorithm in Section
 [[[#selectjsonld]]], passing |document|, and |combinedPointers| as |pointers|.
             </li>
             <li>
@@ -2541,7 +2541,7 @@ Section [[[#createlabelmapfunction]]].
             </li>
             <li>
 Initialize |nquads| to the result of calling the algorithm of section
-[[[#labelreplacementcanonicalizejsonld]]] passing |document|,
+[[[#labelreplacementcanonicalizejsonld]]], passing |document|,
 |labelMapFactoryFunction|, and any custom
 JSON-LD API options. Note: This step transforms the document into an array of
 canonical N-Quads with pseudorandom blank node identifiers based on |labelMap|.
@@ -2671,7 +2671,7 @@ this is 256 bits or 32 bytes.
             </li>
             <li>
 Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
-Section [[[#createhmacidlabelmapfunction]]] passing |hmac|.
+Section [[[#createhmacidlabelmapfunction]]], passing |hmac|.
             </li>
             <li>
 Initialize |groupDefinitions| to a map with an entry with a key of the string

--- a/index.html
+++ b/index.html
@@ -2540,8 +2540,9 @@ Initialize |labelMapFactoryFunction| to the result of calling the algorithm of
 Section [[[#createlabelmapfunction]]].
             </li>
             <li>
-Initialize |nquads| to the result of calling the "labelReplacementCanonicalize"
-algorithm, passing |document|, |labelMapFactoryFunction|, and any custom
+Initialize |nquads| to the result of calling the algorithm of section
+[[[#labelreplacementcanonicalizejsonld]]] passing |document|,
+|labelMapFactoryFunction|, and any custom
 JSON-LD API options. Note: This step transforms the document into an array of
 canonical N-Quads with pseudorandom blank node identifiers based on |labelMap|.
             </li>


### PR DESCRIPTION
This editorial PR addresses issue https://github.com/w3c/vc-di-ecdsa/issues/94 and fixes formatting errors that prevented links back to function definitions in three places.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-di-ecdsa/pull/99.html" title="Last updated on Feb 20, 2025, 6:18 PM UTC (229771c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/99/4bd0545...Wind4Greg:229771c.html" title="Last updated on Feb 20, 2025, 6:18 PM UTC (229771c)">Diff</a>