### PR TITLE
Fix mismatched prCredUnsigned.json description compared to data from ecdsa-sd-2023/prc/

### DIFF
--- a/TestVectors/prCredUnsigned.json
+++ b/TestVectors/prCredUnsigned.json
@@ -12,7 +12,7 @@
       "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P4z/DiPwAG0ALnwgz64QAAAABJRU5ErkJggg=="
        },
     "name": "Permanent Resident Card",
-    "description": "Government of Utopia Permanent Resident Card.",
+    "description": "Permanent Resident Card from Government of Utopia.",
     "credentialSubject": {
       "type": [
         "PermanentResident",


### PR DESCRIPTION
In e11e92c / #89 , some test vectors were added to the repo/document, but then after some discussion within the PR the `description` field within some of the json files was reworked to be different than originally written, which led to drift from the base https://github.com/w3c/vc-di-ecdsa/blob/main/TestVectors/prCredUnsigned.json#L15  file, and potential issues.

In a nutshell, the files within `prc/` were changed from:

```
"Government of Utopia Permanent Resident Card."
```

to:

```
"Permanent Resident Card from Government of Utopia."
```

But the base `prCredUnsigned.json` remained `"Government of Utopia Permanent Resident Card."`

Ideally, there could be some small Github workflow scripts that can sanity-check the fields and values from the base json files with their broken down parts, but for now this should align the base value at least with the values now in `prc/` json files.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/scouttyg/vc-di-ecdsa/pull/103.html" title="Last updated on Apr 15, 2026, 12:32 PM UTC (d75f0ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-di-ecdsa/103/00781de...scouttyg:d75f0ed.html" title="Last updated on Apr 15, 2026, 12:32 PM UTC (d75f0ed)">Diff</a>